### PR TITLE
feat: migrate to ESLint v10 flat config

### DIFF
--- a/Resources/Public/JavaScript/Ckeditor/cowriter.js
+++ b/Resources/Public/JavaScript/Ckeditor/cowriter.js
@@ -56,8 +56,7 @@ export class Cowriter extends Core.Plugin {
         this._service = new AIService();
 
         const editor = this.editor,
-            model = editor.model,
-            view = editor.view;
+            model = editor.model;
 
         // Button to add text at current text cursor position:
         editor.ui.componentFactory.add(Cowriter.pluginName, () => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,28 @@
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+    js.configs.recommended,
+    {
+        files: ['Resources/Public/JavaScript/**/*.js'],
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            globals: {
+                ...globals.browser,
+                TYPO3: 'readonly',
+            },
+        },
+    },
+    {
+        ignores: [
+            'node_modules/',
+            'vendor/',
+            '.Build/',
+            'Build/',
+            'Tests/',
+            'coverage/',
+            'vitest.config.js',
+        ],
+    },
+];

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "lint:fix": "eslint Resources/Public/JavaScript/**/*.js --fix"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.0",
     "@vitest/coverage-v8": "^4.0.0",
-    "eslint": "^9.0.0",
+    "eslint": "^10.0.0",
+    "globals": "^16.0.0",
     "jsdom": "^28.0.0",
     "vitest": "^4.0.0"
   }

--- a/renovate.json
+++ b/renovate.json
@@ -14,12 +14,6 @@
         "digest"
       ],
       "automerge": true
-    },
-    {
-      "matchPackageNames": [
-        "eslint"
-      ],
-      "allowedVersions": "<10.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `eslint.config.js` using the ESLint v10 flat config format with `@eslint/js` recommended rules and `globals` for browser environment
- Updates `eslint` from `^9.0.0` to `^10.0.0`, adds `@eslint/js` and `globals` as devDependencies
- Removes the `allowedVersions: "<10.0.0"` pin for eslint from `renovate.json`
- Fixes unused variable `view` in `cowriter.js` (caught by the new lint run)

Supersedes #69 (Renovate's automatic eslint v10 bump which was closed because it lacked the flat config migration).

## Test plan

- [ ] `npm install` succeeds
- [ ] `npx eslint Resources/Public/JavaScript/**/*.js` passes with zero errors
- [ ] `npm test` (vitest) passes all 39 tests
- [ ] Verify no `.eslintrc*` or `.eslintignore` files remain (they didn't exist before either)