### PR TITLE
chore: add SPDX copyright and license headers

### DIFF
--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 /**
  * Dist config for PHP-CS-Fixer (repo-wide).
  * Copy to .php-cs-fixer.php locally if you want to override anything.
@@ -10,10 +15,8 @@ if (PHP_SAPI !== 'cli') {
 }
 
 $header = <<<EOF
-This file is part of the package netresearch/t3-cowriter.
-
-For the full copyright and license information, please read the
-LICENSE file that was distributed with this source code.
+Copyright (c) 2025-2026 Netresearch DTT GmbH
+SPDX-License-Identifier: GPL-3.0-or-later
 EOF;
 
 $repoRoot = __DIR__ . '/..';

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Domain/DTO/CompleteRequest.php
+++ b/Classes/Domain/DTO/CompleteRequest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Domain/DTO/CompleteResponse.php
+++ b/Classes/Domain/DTO/CompleteResponse.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Domain/DTO/UsageData.php
+++ b/Classes/Domain/DTO/UsageData.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/EventListener/InjectAjaxUrlsListener.php
+++ b/Classes/EventListener/InjectAjaxUrlsListener.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/RateLimitResult.php
+++ b/Classes/Service/RateLimitResult.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/RateLimiterInterface.php
+++ b/Classes/Service/RateLimiterInterface.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/RateLimiterService.php
+++ b/Classes/Service/RateLimiterService.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Configuration/ContentSecurityPolicies.php
+++ b/Configuration/ContentSecurityPolicies.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/E2E/AbstractE2ETestCase.php
+++ b/Tests/E2E/AbstractE2ETestCase.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/E2E/CowriterWorkflowTest.php
+++ b/Tests/E2E/CowriterWorkflowTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Integration/AbstractIntegrationTestCase.php
+++ b/Tests/Integration/AbstractIntegrationTestCase.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Integration/Controller/AjaxControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/AjaxControllerIntegrationTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Support/TestQueryResult.php
+++ b/Tests/Support/TestQueryResult.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Domain/DTO/CompleteRequestTest.php
+++ b/Tests/Unit/Domain/DTO/CompleteRequestTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Domain/DTO/CompleteResponseTest.php
+++ b/Tests/Unit/Domain/DTO/CompleteResponseTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Domain/DTO/UsageDataTest.php
+++ b/Tests/Unit/Domain/DTO/UsageDataTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/EventListener/InjectAjaxUrlsListenerTest.php
+++ b/Tests/Unit/EventListener/InjectAjaxUrlsListenerTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/RateLimitResultTest.php
+++ b/Tests/Unit/Service/RateLimitResultTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/RateLimiterServiceTest.php
+++ b/Tests/Unit/Service/RateLimiterServiceTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/t3-cowriter.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## Summary
- Add SPDX copyright (Netresearch DTT GmbH) and license (GPL-3.0-or-later) headers to all 28 PHP source files
- Supports OpenSSF Best Practices Gold badge criteria (`license_per_file_doc`)

## Test plan
- [ ] CI passes (no functional changes, headers only)