### PR TITLE
ci: enable Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,6 @@ jobs:
       typo3-versions: '["^14.0.2"]'
       typo3-packages: '["typo3/cms-core", "typo3/cms-backend", "typo3/cms-rte-ckeditor"]'
       run-functional-tests: true
+      upload-coverage: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Enable Codecov coverage uploads in CI workflow
- Add `upload-coverage: true` to shared workflow call
- Pass `CODECOV_TOKEN` secret for authenticated uploads

This enables statement coverage tracking via Codecov, required for OpenSSF Best Practices Silver badge (`test_statement_coverage80` criterion).

## Test plan
- [ ] CI runs successfully with coverage enabled
- [ ] Coverage report appears on Codecov
- [ ] Statement coverage >= 80% for Silver badge