### PR TITLE
chore: migrate to centralized CI workflows

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -5,7 +5,7 @@ on:
 permissions: {}
 jobs:
   auto-merge:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/auto-merge-deps.yml@5c3daffcc31504594fdb3aa1d150e8d6a95b24c0 # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 permissions: {}
 jobs:
   ci:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@5c3daffcc31504594fdb3aa1d150e8d6a95b24c0 # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
     permissions:
       contents: read
     with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 jobs:
   analyze:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/codeql.yml@5c3daffcc31504594fdb3aa1d150e8d6a95b24c0 # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,7 +4,7 @@ on:
 permissions: {}
 jobs:
   review:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/dependency-review.yml@5c3daffcc31504594fdb3aa1d150e8d6a95b24c0 # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/dependency-review.yml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,17 @@
+name: Fuzzing
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 0'
+
+permissions: {}
+
+jobs:
+  fuzz:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,16 @@
+name: Greetings
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  greetings:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/greetings.yml@main
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  labeler:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/labeler.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,23 @@
+name: License Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'composer.json'
+      - 'package.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'composer.json'
+      - 'package.json'
+  schedule:
+    - cron: '0 9 * * 1'
+
+permissions: {}
+
+jobs:
+  license-check:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,15 @@
+name: Lock Threads
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  lock:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/lock.yml@main
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,112 +1,15 @@
 name: PR Quality Gates
+
 on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+
 permissions: {}
+
 jobs:
-  quality-gate:
-    name: PR Size Check
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+  pr-quality:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/pr-quality.yml@main
     permissions:
+      contents: read
       pull-requests: write
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Check PR size
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-
-            const additions = pr.additions || 0;
-            const deletions = pr.deletions || 0;
-            const totalChanges = additions + deletions;
-            const changedFiles = pr.changed_files || 0;
-
-            core.info(`PR #${pr.number}: +${additions} -${deletions} (${totalChanges} total) across ${changedFiles} files`);
-
-            if (totalChanges > 1000) {
-              const body = [
-                '> [!WARNING]',
-                `> **Large PR detected**: ${totalChanges} lines changed across ${changedFiles} files.`,
-                '> Consider splitting this PR into smaller, focused changes for easier review.',
-              ].join('\n');
-
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-
-              core.warning(`PR has ${totalChanges} lines changed — consider splitting`);
-            }
-
-  auto-approve:
-    name: Auto-Approve (solo maintainer)
-    runs-on: ubuntu-latest
-    needs: quality-gate
-    if: github.event.pull_request.draft == false
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Auto-approve PR
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-
-            // Only auto-approve PRs from the repository owner or known bots
-            const trustedAuthors = [
-              'dependabot[bot]',
-              'renovate[bot]',
-            ];
-
-            const { data: repoData } = await github.rest.repos.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-
-            const isOwner = pr.user.login === repoData.owner.login;
-            const isTrustedBot = trustedAuthors.includes(pr.user.login);
-
-            if (!isOwner && !isTrustedBot) {
-              core.info(`PR author ${pr.user.login} is not the repo owner or a trusted bot — skipping auto-approve`);
-              return;
-            }
-
-            // Check if there are any pending reviewers (e.g. Copilot still reviewing)
-            const { data: reviewRequests } = await github.rest.pulls.listRequestedReviewers({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-            });
-
-            if (reviewRequests.users.length > 0 || reviewRequests.teams.length > 0) {
-              core.info('Pending reviewers detected — skipping auto-approve to avoid race condition');
-              return;
-            }
-
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-              event: 'APPROVE',
-              body: 'Auto-approved: quality gates passed.',
-            });
-
-            core.info(`Auto-approved PR #${pr.number}`);

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -5,7 +5,7 @@ on:
 permissions: {}
 jobs:
   publish:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@5c3daffcc31504594fdb3aa1d150e8d6a95b24c0 # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
     permissions:
       contents: read
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,133 +1,19 @@
 name: Release
+
 on:
   push:
     tags:
       - 'v*'
+
 permissions: {}
+
 jobs:
   release:
-    name: Build, sign and release
-    runs-on: ubuntu-latest
+    uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@main
     permissions:
       contents: write
       id-token: write
       attestations: write
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Determine version
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
-        with:
-          php-version: '8.5'
-          tools: composer:v2
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-
-      - name: Install composer dependencies
-        run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress
-
-      - name: Create release archives
-        run: |
-          ARCHIVE_NAME="t3-cowriter-${{ steps.version.outputs.version }}"
-          mkdir -p dist
-
-          tar czf "dist/${ARCHIVE_NAME}.tar.gz" \
-            --exclude='.git' \
-            --exclude='.github' \
-            --exclude='.ddev' \
-            --exclude='.Build' \
-            --exclude='Tests' \
-            --exclude='dist' \
-            --exclude='.conformance-reports' \
-            --exclude='.editorconfig' \
-            --exclude='.gitattributes' \
-            --exclude='.gitignore' \
-            --exclude='.php-cs-fixer.cache' \
-            --exclude='AGENTS.md' \
-            --exclude='Classes/AGENTS.md' \
-            --exclude='Resources/AGENTS.md' \
-            --exclude='Tests/AGENTS.md' \
-            --exclude='Makefile' \
-            --exclude='docs' \
-            --exclude='eslint.config.js' \
-            --exclude='package.json' \
-            --exclude='package-lock.json' \
-            --exclude='node_modules' \
-            --exclude='phpunit.xml' \
-            --exclude='renovate.json' \
-            --exclude='vitest.config.js' \
-            --exclude='Build' \
-            .
-
-          # Create zip with the same exclusions
-          zip -r "dist/${ARCHIVE_NAME}.zip" . \
-            -x '.git/*' \
-            -x '.github/*' \
-            -x '.ddev/*' \
-            -x '.Build/*' \
-            -x 'Tests/*' \
-            -x 'dist/*' \
-            -x '.conformance-reports/*' \
-            -x '.editorconfig' \
-            -x '.gitattributes' \
-            -x '.gitignore' \
-            -x '.php-cs-fixer.cache' \
-            -x 'AGENTS.md' \
-            -x 'Classes/AGENTS.md' \
-            -x 'Resources/AGENTS.md' \
-            -x 'Tests/AGENTS.md' \
-            -x 'Makefile' \
-            -x 'docs/*' \
-            -x 'eslint.config.js' \
-            -x 'package.json' \
-            -x 'package-lock.json' \
-            -x 'node_modules/*' \
-            -x 'phpunit.xml' \
-            -x 'renovate.json' \
-            -x 'vitest.config.js' \
-            -x 'Build/*'
-
-      - name: Generate SBOM
-        uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11 # v0.23.0
-        with:
-          path: .
-          format: spdx-json
-          output-file: dist/t3-cowriter-${{ steps.version.outputs.version }}.sbom.spdx.json
-
-      - name: Generate SHA256 checksums
-        working-directory: dist
-        run: sha256sum * > SHA256SUMS.txt
-
-      - name: Sign artifacts with Cosign (keyless)
-        working-directory: dist
-        run: |
-          for file in *.tar.gz *.zip *.spdx.json SHA256SUMS.txt; do
-            cosign sign-blob --yes "$file" --output-signature "${file}.sig" --output-certificate "${file}.pem"
-          done
-
-      - name: Generate build provenance attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: |
-            dist/t3-cowriter-${{ steps.version.outputs.version }}.tar.gz
-            dist/t3-cowriter-${{ steps.version.outputs.version }}.zip
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          generate_release_notes: true
-          files: dist/*
-          fail_on_unmatched_files: true
+    with:
+      archive-prefix: 't3-cowriter'
+      package-name: 'netresearch/t3-cowriter'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,7 @@ on:
 permissions: {}
 jobs:
   scorecard:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/scorecard.yml@5c3daffcc31504594fdb3aa1d150e8d6a95b24c0 # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/scorecard.yml@main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,5 @@
 name: Security
+
 on:
   push:
     branches: [main]
@@ -6,49 +7,14 @@ on:
     branches: [main]
   schedule:
     - cron: '0 7 * * 1'
-permissions:
-  contents: read
+
+permissions: {}
+
 jobs:
-  security-audit:
-    name: Composer Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
-        with:
-          php-version: '8.5'
-          tools: composer:v2
-
-      - name: Composer audit
-        run: composer audit --format=plain
-
-  npm-audit:
-    name: npm Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 22
-
-      - name: Generate lockfile
-        run: npm i --package-lock-only
-
-      - name: npm audit
-        run: npm audit --audit-level=high
+  security:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,4 +1,5 @@
 name: SLSA Provenance
+
 on:
   workflow_run:
     workflows: ["Release"]
@@ -9,69 +10,15 @@ on:
         description: 'Release version tag (e.g. v4.0.0)'
         required: true
         type: string
+
 permissions: {}
+
 jobs:
-  prepare:
-    name: Prepare provenance subjects
-    runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
-    permissions:
-      contents: read
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      base64-subjects: ${{ steps.subjects.outputs.base64-subjects }}
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
-
-      - name: Determine version
-        id: version
-        env:
-          INPUT_VERSION: ${{ inputs.version }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          if [ -n "$INPUT_VERSION" ]; then
-            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Download release assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          mkdir -p artifacts
-          cd artifacts
-          gh release download "$VERSION" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pattern '*.tar.gz' \
-            --pattern '*.zip' \
-            --pattern '*.spdx.json' \
-            --pattern 'SHA256SUMS.txt'
-
-      - name: Generate base64-encoded subjects
-        id: subjects
-        working-directory: artifacts
-        run: |
-          SUBJECTS=$(sha256sum *.tar.gz *.zip *.spdx.json SHA256SUMS.txt | base64 -w0)
-          echo "base64-subjects=$SUBJECTS" >> "$GITHUB_OUTPUT"
-
   provenance:
-    name: Generate SLSA provenance
-    needs: prepare
+    uses: netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml@main
     permissions:
       actions: read
       contents: write
       id-token: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
-      base64-subjects: ${{ needs.prepare.outputs.base64-subjects }}
-      upload-assets: true
-      upload-tag-name: ${{ needs.prepare.outputs.version }}
-      compile-generator: true
-      private-repository: true
+      version: ${{ inputs.version }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Update 6 existing workflows from SHA pin (`5c3daff`) to `@main` reference, preserving all inputs/permissions/triggers:
  - `ci.yml` - CI (php-versions, typo3-versions, typo3-packages, functional tests, coverage)
  - `codeql.yml` - CodeQL
  - `dependency-review.yml` - Dependency Review
  - `scorecard.yml` - OpenSSF Scorecard
  - `auto-merge-deps.yml` - Auto-merge dependency PRs
  - `publish-to-ter.yml` - Publish to TER
- Replace 4 local workflows with centralized callers from `netresearch/typo3-ci-workflows@main`:
  - `pr-quality.yml` - PR Quality Gates
  - `release.yml` - Release (archive-prefix: `t3-cowriter`, package-name: `netresearch/t3-cowriter`)
  - `security.yml` - Security
  - `slsa-provenance.yml` - SLSA Provenance
- Add 6 new standard workflows as centralized callers:
  - `fuzz.yml` - Fuzzing
  - `stale.yml` - Stale Issues
  - `lock.yml` - Lock Threads
  - `greetings.yml` - Greetings
  - `labeler.yml` - PR Labeler
  - `license-check.yml` - License Check

All workflows now delegate to reusable workflows in `netresearch/typo3-ci-workflows`, ensuring consistent CI across all Netresearch TYPO3 extensions.

## Test plan

- [ ] Verify CI workflow runs pass on this PR (especially ci.yml with preserved inputs)
- [ ] Verify PR Quality Gates workflow triggers correctly
- [ ] Confirm all 6 previously SHA-pinned workflows now reference `@main`
- [ ] Confirm no duplicate workflow runs from old local definitions