### PR TITLE
fix: add merge_group trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 6 * * 1'
 


### PR DESCRIPTION
## Summary
- Add `merge_group:` event trigger to CI workflow so merge queue checks run properly
- Without this trigger, PRs get stuck in the merge queue waiting for checks that never start

## Test plan
- [ ] CI checks pass on this PR
- [ ] Merge queue properly triggers checks after merge