### PR TITLE
fix: remove redundant htmlspecialchars from JSON API responses

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -39,8 +39,8 @@ use TYPO3\CMS\Core\Http\Stream;
  * Provides backend API endpoints for chat and completion requests,
  * routing them through the centralized LlmServiceManager.
  *
- * JSON responses carry raw data — JSON encoding prevents XSS by design.
- * Content sanitization for DOM insertion is the frontend's responsibility.
+ * Returns raw data in JSON responses — no server-side HTML escaping.
+ * The frontend sanitizes content via DOMParser before DOM insertion.
  */
 #[AsController]
 final readonly class AjaxController

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -39,7 +39,8 @@ use TYPO3\CMS\Core\Http\Stream;
  * Provides backend API endpoints for chat and completion requests,
  * routing them through the centralized LlmServiceManager.
  *
- * JSON responses carry raw data; HTML escaping is the frontend's responsibility.
+ * JSON responses carry raw data — JSON encoding prevents XSS by design.
+ * Content sanitization for DOM insertion is the frontend's responsibility.
  */
 #[AsController]
 final readonly class AjaxController
@@ -140,9 +141,9 @@ final readonly class AjaxController
 
             return $this->jsonResponseWithRateLimitHeaders([
                 'success'      => true,
-                'content'      => htmlspecialchars($response->content ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-                'model'        => htmlspecialchars($response->model ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-                'finishReason' => htmlspecialchars($response->finishReason ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+                'content'      => $response->content ?? '',
+                'model'        => $response->model ?? '',
+                'finishReason' => $response->finishReason ?? '',
             ], $rateLimitResult);
         } catch (ProviderException $e) {
             $this->logger->error('Chat provider error', ['exception' => $e->getMessage()]);
@@ -313,13 +314,13 @@ final readonly class AjaxController
             $generator = $this->llmServiceManager->streamChatWithConfiguration($messages, $configuration);
 
             foreach ($generator as $chunk) {
-                $chunks[] = 'data: ' . json_encode(['content' => htmlspecialchars($chunk, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')], JSON_THROW_ON_ERROR) . "\n\n";
+                $chunks[] = 'data: ' . json_encode(['content' => $chunk], JSON_THROW_ON_ERROR) . "\n\n";
             }
 
             // Add final "done" event
             $chunks[] = 'data: ' . json_encode([
                 'done'  => true,
-                'model' => htmlspecialchars($configuration->getModelId(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+                'model' => $configuration->getModelId(),
             ], JSON_THROW_ON_ERROR) . "\n\n";
 
             $body = implode('', $chunks);
@@ -408,9 +409,9 @@ final readonly class AjaxController
 
             $list[] = [
                 'uid'         => $task->getUid(),
-                'identifier'  => htmlspecialchars($task->getIdentifier(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-                'name'        => htmlspecialchars($task->getName(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-                'description' => htmlspecialchars($task->getDescription(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+                'identifier'  => $task->getIdentifier(),
+                'name'        => $task->getName(),
+                'description' => $task->getDescription(),
             ];
         }
 

--- a/Classes/Domain/DTO/CompleteResponse.php
+++ b/Classes/Domain/DTO/CompleteResponse.php
@@ -15,8 +15,8 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 /**
  * Response DTO for completion AJAX endpoint.
  *
- * JSON responses carry raw data — JSON encoding prevents XSS by design.
- * Content sanitization for DOM insertion is the frontend's responsibility.
+ * Returns raw data in JSON responses — no server-side HTML escaping.
+ * The frontend sanitizes content via DOMParser before DOM insertion.
  *
  * @internal
  */
@@ -35,8 +35,8 @@ final readonly class CompleteResponse implements JsonSerializable
     /**
      * Create a successful response from nr-llm CompletionResponse.
      *
-     * Returns raw content — JSON encoding prevents XSS by design.
-     * Frontend sanitizes content before DOM insertion.
+     * Returns raw content without server-side HTML escaping.
+     * The frontend sanitizes content via DOMParser before DOM insertion.
      */
     public static function success(CompletionResponse $response): self
     {

--- a/Classes/Domain/DTO/CompleteResponse.php
+++ b/Classes/Domain/DTO/CompleteResponse.php
@@ -15,8 +15,8 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 /**
  * Response DTO for completion AJAX endpoint.
  *
- * All LLM output fields are HTML-escaped server-side to prevent XSS.
- * The frontend decodes entities where raw HTML is needed (e.g. CKEditor insertion).
+ * JSON responses carry raw data — JSON encoding prevents XSS by design.
+ * Content sanitization for DOM insertion is the frontend's responsibility.
  *
  * @internal
  */
@@ -35,15 +35,16 @@ final readonly class CompleteResponse implements JsonSerializable
     /**
      * Create a successful response from nr-llm CompletionResponse.
      *
-     * All string fields are HTML-escaped to prevent XSS when rendered in the browser.
+     * Returns raw content — JSON encoding prevents XSS by design.
+     * Frontend sanitizes content before DOM insertion.
      */
     public static function success(CompletionResponse $response): self
     {
         return new self(
             success: true,
-            content: htmlspecialchars($response->content ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-            model: htmlspecialchars($response->model ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-            finishReason: htmlspecialchars($response->finishReason ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            content: $response->content ?? '',
+            model: $response->model ?? '',
+            finishReason: $response->finishReason ?? '',
             usage: UsageData::fromUsageStatistics($response->usage),
             error: null,
             retryAfter: null,

--- a/Resources/Public/JavaScript/Ckeditor/CowriterDialog.js
+++ b/Resources/Public/JavaScript/Ckeditor/CowriterDialog.js
@@ -251,15 +251,12 @@ export class CowriterDialog {
                     );
 
                     if (result.success && result.content) {
-                        // Server returns HTML-escaped content for XSS safety;
-                        // decode entities to recover the original HTML for CKEditor.
-                        const decoded = this._decodeEntities(result.content);
                         preview.replaceChildren();
-                        const safeBody = this._sanitizeHtml(decoded);
+                        const safeBody = this._sanitizeHtml(result.content);
                         while (safeBody.firstChild) {
                             preview.appendChild(safeBody.firstChild);
                         }
-                        resultContent = decoded;
+                        resultContent = result.content;
                         state = 'result';
 
                         if (result.model) {
@@ -539,23 +536,6 @@ export class CowriterDialog {
         row.appendChild(removeBtn);
 
         return row;
-    }
-
-    /**
-     * Decode HTML entities back to their original characters.
-     *
-     * The server HTML-escapes all LLM output for XSS safety.
-     * This reverses the escaping so the content can be used as HTML in CKEditor.
-     * Uses a textarea element which safely decodes entities without executing scripts.
-     *
-     * @param {string} escaped
-     * @returns {string} The decoded HTML string
-     * @private
-     */
-    _decodeEntities(escaped) {
-        const textarea = document.createElement('textarea');
-        textarea.innerHTML = escaped;
-        return textarea.value;
     }
 
     /**

--- a/Tests/E2E/CowriterWorkflowTest.php
+++ b/Tests/E2E/CowriterWorkflowTest.php
@@ -356,12 +356,12 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
         ]);
         $result = $stack['controller']->chatAction($request);
 
-        // Assert: All fields escaped
+        // Assert: Raw content returned — frontend sanitizes before DOM insertion
         $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
         self::assertIsArray($data);
-        self::assertStringNotContainsString('<', $data['content']);
-        self::assertStringNotContainsString('<', $data['model']);
-        self::assertStringNotContainsString('<', $data['finishReason']);
+        self::assertSame('<script>steal()</script>', $data['content']);
+        self::assertSame('<img onerror=alert(1)>', $data['model']);
+        self::assertSame('<svg onload=hack()>', $data['finishReason']);
     }
 
     // =========================================================================
@@ -993,7 +993,7 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
     }
 
     #[Test]
-    public function getTasksWorkflowEscapesXss(): void
+    public function getTasksWorkflowReturnsRawContent(): void
     {
         $stack = $this->createCompleteStack([]);
 
@@ -1014,9 +1014,10 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
         self::assertIsArray($data);
         self::assertTrue($data['success']);
         self::assertCount(1, $data['tasks']);
-        self::assertStringNotContainsString('<script>', $data['tasks'][0]['identifier']);
-        self::assertStringNotContainsString('<img', $data['tasks'][0]['name']);
-        self::assertStringNotContainsString('<svg', $data['tasks'][0]['description']);
+        // Raw content — JSON encoding is the transport safety, frontend sanitizes
+        self::assertSame('<script>alert(1)</script>', $data['tasks'][0]['identifier']);
+        self::assertSame('<img onerror=hack>', $data['tasks'][0]['name']);
+        self::assertSame('<svg onload=steal()>', $data['tasks'][0]['description']);
     }
 
     #[Test]

--- a/Tests/E2E/CowriterWorkflowTest.php
+++ b/Tests/E2E/CowriterWorkflowTest.php
@@ -166,7 +166,7 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
 
     #[Test]
     #[DataProvider('xssPayloadProvider')]
-    public function completeWorkflowEscapesXssFromLlm(string $maliciousContent, string $description): void
+    public function completeWorkflowReturnsRawLlmContent(string $maliciousContent, string $description): void
     {
         // Arrange: LLM returns malicious content (simulating prompt injection attack)
         $llmResponse = $this->createOpenAiResponse(
@@ -183,15 +183,12 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
         $request = $this->createJsonRequest(['prompt' => 'Improve this text']);
         $result  = $stack['controller']->completeAction($request);
 
-        // Assert: XSS content is escaped through the entire stack
+        // Assert: Raw content returned in JSON (JSON encoding is inherently XSS-safe;
+        // frontend sanitizes via DOMParser before DOM insertion)
         $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
         self::assertIsArray($data);
         self::assertTrue($data['success']);
-
-        // Verify HTML entities are used, not raw tags
-        self::assertStringNotContainsString('<', $data['content'], "Raw < found in: {$description}");
-        self::assertStringNotContainsString('>', $data['content'], "Raw > found in: {$description}");
-        self::assertStringContainsString('&lt;', $data['content'], "Missing escaped < in: {$description}");
+        self::assertSame($maliciousContent, $data['content'], "Content mismatch for: {$description}");
     }
 
     /**
@@ -226,9 +223,9 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
     }
 
     #[Test]
-    public function completeWorkflowEscapesXssInModelName(): void
+    public function completeWorkflowReturnsRawModelName(): void
     {
-        // Arrange: LLM returns XSS in model field (edge case)
+        // Arrange: LLM returns special chars in model field
         $llmResponse = new CompletionResponse(
             content: 'Normal response',
             model: '<script>alert("xss")</script>',
@@ -246,11 +243,10 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
         $request = $this->createJsonRequest(['prompt' => 'Test']);
         $result  = $stack['controller']->completeAction($request);
 
-        // Assert: Model field is also escaped
+        // Assert: Raw content in JSON (JSON encoding is inherently safe)
         $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
         self::assertIsArray($data);
-        self::assertStringNotContainsString('<script>', $data['model']);
-        self::assertStringContainsString('&lt;script&gt;', $data['model']);
+        self::assertSame('<script>alert("xss")</script>', $data['model']);
     }
 
     // =========================================================================
@@ -813,7 +809,7 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
     }
 
     #[Test]
-    public function streamWorkflowEscapesXssInChunks(): void
+    public function streamWorkflowReturnsRawContentInChunks(): void
     {
         $stack  = $this->createStreamingStack(['<script>alert(1)</script>']);
         $config = $this->createLlmConfiguration();
@@ -825,17 +821,16 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
         $events = $this->parseSseEvents((string) $result->getBody());
         self::assertCount(2, $events); // 1 content + 1 done
 
-        // XSS content must be escaped
-        self::assertStringNotContainsString('<script>', $events[0]['content']);
-        self::assertStringContainsString('&lt;script&gt;', $events[0]['content']);
+        // Raw content in JSON-encoded SSE data (JSON encoding is inherently safe)
+        self::assertSame('<script>alert(1)</script>', $events[0]['content']);
     }
 
     #[Test]
-    public function streamWorkflowEscapesXssInModelName(): void
+    public function streamWorkflowReturnsRawModelName(): void
     {
         $stack = $this->createStreamingStack(['Hello']);
 
-        // Create config with XSS in model name
+        // Create config with special chars in model name
         $config = self::createStub(\Netresearch\NrLlm\Domain\Model\LlmConfiguration::class);
         $config->method('getIdentifier')->willReturn('test');
         $config->method('getName')->willReturn('Test');
@@ -849,8 +844,7 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
         $events    = $this->parseSseEvents((string) $result->getBody());
         $doneEvent = end($events);
         self::assertTrue($doneEvent['done']);
-        self::assertStringNotContainsString('<img', $doneEvent['model']);
-        self::assertStringContainsString('&lt;img', $doneEvent['model']);
+        self::assertSame('<img onerror=alert(1)>', $doneEvent['model']);
     }
 
     #[Test]
@@ -1226,7 +1220,7 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
     }
 
     #[Test]
-    public function executeTaskWorkflowEscapesXssFromLlm(): void
+    public function executeTaskWorkflowReturnsRawLlmContent(): void
     {
         $llmResponse = $this->createOpenAiResponse(
             content: '<script>document.cookie</script>Malicious response',
@@ -1249,11 +1243,12 @@ final class CowriterWorkflowTest extends AbstractE2ETestCase
         ]);
         $result = $stack['controller']->executeTaskAction($request);
 
+        // Raw content in JSON (JSON encoding is inherently safe;
+        // frontend sanitizes via DOMParser before DOM insertion)
         $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
         self::assertIsArray($data);
         self::assertTrue($data['success']);
-        self::assertStringNotContainsString('<script>', $data['content']);
-        self::assertStringContainsString('&lt;script&gt;', $data['content']);
+        self::assertSame('<script>document.cookie</script>Malicious response', $data['content']);
     }
 
     #[Test]

--- a/Tests/Integration/Controller/AjaxControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/AjaxControllerIntegrationTest.php
@@ -168,9 +168,9 @@ final class AjaxControllerIntegrationTest extends AbstractIntegrationTestCase
 
     #[Test]
     #[DataProvider('xssPayloadProvider')]
-    public function completeActionEscapesXssPayloadsInContent(string $payload, string $description): void
+    public function completeActionReturnsRawContentForFrontendSanitization(string $payload, string $description): void
     {
-        // Arrange: LLM returns malicious content
+        // Arrange: LLM returns potentially dangerous content
         $config = $this->createLlmConfiguration();
         $this->configRepoMock->method('findDefault')->willReturn($config);
 
@@ -181,14 +181,10 @@ final class AjaxControllerIntegrationTest extends AbstractIntegrationTestCase
         $request = $this->createJsonRequest(['prompt' => 'Test prompt']);
         $result  = $this->subject->completeAction($request);
 
-        // Assert: XSS payload is HTML-escaped (angle brackets become entities)
+        // Assert: Raw content returned — JSON encoding is the transport safety,
+        // frontend sanitizes via DOMParser before DOM insertion
         $data = $this->assertSuccessfulJsonResponse($result);
-        // Check that < and > are escaped to &lt; and &gt;
-        self::assertStringNotContainsString('<', $data['content'], "Unescaped < in: {$description}");
-        self::assertStringNotContainsString('>', $data['content'], "Unescaped > in: {$description}");
-        // Verify the escaped versions are present
-        self::assertStringContainsString('&lt;', $data['content'], "Missing escaped < in: {$description}");
-        self::assertStringContainsString('&gt;', $data['content'], "Missing escaped > in: {$description}");
+        self::assertSame($payload, $data['content'], "Content should be raw for: {$description}");
     }
 
     /**
@@ -291,13 +287,13 @@ final class AjaxControllerIntegrationTest extends AbstractIntegrationTestCase
     }
 
     #[Test]
-    public function chatActionEscapesXssInAllFields(): void
+    public function chatActionReturnsRawContentInAllFields(): void
     {
         // Arrange: Setup configuration
         $config = $this->createLlmConfiguration();
         $this->configRepoMock->method('findDefault')->willReturn($config);
 
-        // Arrange: Response with XSS in all fields
+        // Arrange: Response with HTML in all fields
         $response = new CompletionResponse(
             content: '<script>alert(1)</script>',
             model: '<img onerror=alert(2)>',
@@ -313,12 +309,12 @@ final class AjaxControllerIntegrationTest extends AbstractIntegrationTestCase
         ]);
         $result = $this->subject->chatAction($request);
 
-        // Assert: All fields are escaped (< and > become &lt; and &gt;)
+        // Assert: Raw content returned — frontend sanitizes before DOM insertion
         $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
         self::assertIsArray($data);
-        self::assertStringNotContainsString('<', $data['content']);
-        self::assertStringNotContainsString('<', $data['model']);
-        self::assertStringNotContainsString('<', $data['finishReason']);
+        self::assertSame('<script>alert(1)</script>', $data['content']);
+        self::assertSame('<img onerror=alert(2)>', $data['model']);
+        self::assertSame('<svg onload=alert(3)>', $data['finishReason']);
     }
 
     // =========================================================================

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -920,7 +920,7 @@ final class AjaxControllerTest extends TestCase
         $events    = array_filter(explode("\n\n", $body), static fn (string $s): bool => $s !== '');
         $lastEvent = json_decode(substr(end($events), 6), true);
         $this->assertTrue($lastEvent['done']);
-        // Model is returned raw — JSON encoding prevents XSS
+        // Raw content — frontend sanitizes before DOM insertion
         $this->assertSame("test-model's", $lastEvent['model']);
     }
 
@@ -1501,7 +1501,7 @@ final class AjaxControllerTest extends TestCase
         $response = $this->subject->getTasksAction($this->createMock(ServerRequestInterface::class));
 
         $data = $this->decodeJsonResponse($response);
-        // Raw content — JSON encoding prevents XSS by design
+        // Raw content — frontend sanitizes before DOM insertion
         self::assertSame('fix<test>', $data['tasks'][0]['identifier']);
         self::assertSame('Fix Grammar & Spelling', $data['tasks'][0]['name']);
         self::assertSame('Desc with "quotes"', $data['tasks'][0]['description']);
@@ -1521,7 +1521,7 @@ final class AjaxControllerTest extends TestCase
         $data = $this->decodeJsonResponse($response);
         self::assertTrue($data['success']);
         self::assertCount(1, $data['tasks']);
-        // Raw content — JSON encoding prevents XSS by design
+        // Raw content — frontend sanitizes before DOM insertion
         self::assertSame("it's", $data['tasks'][0]['identifier']);
         self::assertSame("Task's Name", $data['tasks'][0]['name']);
         self::assertSame("It's a description", $data['tasks'][0]['description']);

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -302,7 +302,7 @@ final class AjaxControllerTest extends TestCase
     }
 
     #[Test]
-    public function chatActionEscapesHtmlInResponse(): void
+    public function chatActionReturnsRawContentInResponse(): void
     {
         $messages = [['role' => 'user', 'content' => 'Hello']];
         $config   = $this->createConfigurationMock();
@@ -325,9 +325,9 @@ final class AjaxControllerTest extends TestCase
 
         $data = $this->decodeJsonResponse($response);
         $this->assertTrue($data['success']);
-        $this->assertSame('&lt;p&gt;Hello &lt;strong&gt;world&lt;/strong&gt;&lt;/p&gt;', $data['content']);
-        $this->assertSame('model&#039;s-name', $data['model']);
-        $this->assertSame('it&#039;s done', $data['finishReason']);
+        $this->assertSame('<p>Hello <strong>world</strong></p>', $data['content']);
+        $this->assertSame("model's-name", $data['model']);
+        $this->assertSame("it's done", $data['finishReason']);
     }
 
     // ===========================================
@@ -416,7 +416,7 @@ final class AjaxControllerTest extends TestCase
     }
 
     #[Test]
-    public function completeActionEscapesHtmlInContent(): void
+    public function completeActionReturnsRawHtmlContent(): void
     {
         $config = $this->createConfigurationMock();
         $this->configRepositoryMock
@@ -432,7 +432,7 @@ final class AjaxControllerTest extends TestCase
         $response = $this->subject->completeAction($request);
 
         $data = $this->decodeJsonResponse($response);
-        $this->assertSame('&lt;p&gt;Improved &lt;strong&gt;text&lt;/strong&gt;&lt;/p&gt;', $data['content']);
+        $this->assertSame('<p>Improved <strong>text</strong></p>', $data['content']);
     }
 
     #[Test]
@@ -796,7 +796,7 @@ final class AjaxControllerTest extends TestCase
     }
 
     #[Test]
-    public function streamActionEscapesHtmlInSseChunks(): void
+    public function streamActionReturnsRawHtmlInSseChunks(): void
     {
         $config = $this->createConfigurationMock();
         $this->configRepositoryMock->method('findDefault')->willReturn($config);
@@ -813,14 +813,14 @@ final class AjaxControllerTest extends TestCase
         $response->getBody()->rewind();
         $body = $response->getBody()->getContents();
 
-        // HTML is escaped in SSE data
+        // Raw content in SSE data (JSON encoding handles safety)
         $events     = array_filter(explode("\n\n", $body), static fn (string $s): bool => $s !== '');
         $firstEvent = json_decode(substr(reset($events), 6), true);
-        $this->assertSame('&lt;p&gt;Hello&lt;/p&gt;', $firstEvent['content']);
+        $this->assertSame('<p>Hello</p>', $firstEvent['content']);
     }
 
     #[Test]
-    public function streamActionEscapesSpecialCharactersInSseChunks(): void
+    public function streamActionPreservesSpecialCharactersInSseChunks(): void
     {
         $config = $this->createConfigurationMock();
         $this->configRepositoryMock->method('findDefault')->willReturn($config);
@@ -837,8 +837,10 @@ final class AjaxControllerTest extends TestCase
         $response->getBody()->rewind();
         $body = $response->getBody()->getContents();
 
-        // Single quotes are HTML-escaped
-        $this->assertStringContainsString('It&#039;s a test', $body);
+        // Raw content preserved in JSON-encoded SSE data
+        $events     = array_filter(explode("\n\n", $body), static fn (string $s): bool => $s !== '');
+        $firstEvent = json_decode(substr(reset($events), 6), true);
+        $this->assertSame("It's a test", $firstEvent['content']);
     }
 
     #[Test]
@@ -918,8 +920,8 @@ final class AjaxControllerTest extends TestCase
         $events    = array_filter(explode("\n\n", $body), static fn (string $s): bool => $s !== '');
         $lastEvent = json_decode(substr(end($events), 6), true);
         $this->assertTrue($lastEvent['done']);
-        // Model is HTML-escaped
-        $this->assertSame('test-model&#039;s', $lastEvent['model']);
+        // Model is returned raw — JSON encoding prevents XSS
+        $this->assertSame("test-model's", $lastEvent['model']);
     }
 
     #[Test]
@@ -1488,7 +1490,7 @@ final class AjaxControllerTest extends TestCase
     }
 
     #[Test]
-    public function getTasksActionEscapesTaskFields(): void
+    public function getTasksActionReturnsRawTaskFields(): void
     {
         $task = $this->createTaskMock(1, 'fix<test>', 'Fix Grammar & Spelling', 'Desc with "quotes"', true);
 
@@ -1499,18 +1501,15 @@ final class AjaxControllerTest extends TestCase
         $response = $this->subject->getTasksAction($this->createMock(ServerRequestInterface::class));
 
         $data = $this->decodeJsonResponse($response);
-        // HTML-escaped to prevent XSS
-        self::assertSame('fix&lt;test&gt;', $data['tasks'][0]['identifier']);
-        self::assertSame('Fix Grammar &amp; Spelling', $data['tasks'][0]['name']);
-        self::assertSame('Desc with &quot;quotes&quot;', $data['tasks'][0]['description']);
+        // Raw content — JSON encoding prevents XSS by design
+        self::assertSame('fix<test>', $data['tasks'][0]['identifier']);
+        self::assertSame('Fix Grammar & Spelling', $data['tasks'][0]['name']);
+        self::assertSame('Desc with "quotes"', $data['tasks'][0]['description']);
     }
 
     #[Test]
-    public function getTasksActionEscapesSingleQuotesInTaskFields(): void
+    public function getTasksActionPreservesSingleQuotesInTaskFields(): void
     {
-        // Kills BitwiseOr mutants #6 and #7:
-        // ENT_QUOTES | ENT_SUBSTITUTE → ENT_QUOTES & ENT_SUBSTITUTE
-        // With ENT_QUOTES & ENT_SUBSTITUTE (= 0), single quotes are NOT escaped
         $task = $this->createTaskMock(1, "it's", "Task's Name", "It's a description", true);
 
         $this->taskRepositoryMock
@@ -1522,10 +1521,10 @@ final class AjaxControllerTest extends TestCase
         $data = $this->decodeJsonResponse($response);
         self::assertTrue($data['success']);
         self::assertCount(1, $data['tasks']);
-        // Single quotes MUST be escaped to &#039; — proves ENT_QUOTES is in effect
-        self::assertSame('it&#039;s', $data['tasks'][0]['identifier']);
-        self::assertSame('Task&#039;s Name', $data['tasks'][0]['name']);
-        self::assertSame('It&#039;s a description', $data['tasks'][0]['description']);
+        // Raw content — JSON encoding prevents XSS by design
+        self::assertSame("it's", $data['tasks'][0]['identifier']);
+        self::assertSame("Task's Name", $data['tasks'][0]['name']);
+        self::assertSame("It's a description", $data['tasks'][0]['description']);
     }
 
     #[Test]

--- a/Tests/Unit/Domain/DTO/CompleteResponseTest.php
+++ b/Tests/Unit/Domain/DTO/CompleteResponseTest.php
@@ -37,51 +37,36 @@ final class CompleteResponseTest extends TestCase
     }
 
     #[Test]
-    public function successEscapesHtmlInContent(): void
+    public function successPreservesRawHtmlContent(): void
     {
         $completionResponse = $this->createCompletionResponse('<p>Hello <strong>world</strong></p>');
 
         $response = CompleteResponse::success($completionResponse);
 
-        $this->assertSame('&lt;p&gt;Hello &lt;strong&gt;world&lt;/strong&gt;&lt;/p&gt;', $response->content);
+        $this->assertSame('<p>Hello <strong>world</strong></p>', $response->content);
     }
 
     #[Test]
-    #[DataProvider('escapedContentProvider')]
-    public function successEscapesSpecialCharactersInContent(string $input, string $expectedContent): void
+    #[DataProvider('rawContentProvider')]
+    public function successPreservesRawContent(string $input): void
     {
         $completionResponse = $this->createCompletionResponse($input);
 
         $response = CompleteResponse::success($completionResponse);
 
-        $this->assertSame($expectedContent, $response->content);
+        $this->assertSame($input, $response->content);
     }
 
     /**
-     * @return iterable<string, array{string, string}>
+     * @return iterable<string, array{string}>
      */
-    public static function escapedContentProvider(): iterable
+    public static function rawContentProvider(): iterable
     {
-        yield 'HTML tags escaped' => [
-            '<p>Hello <strong>world</strong></p>',
-            '&lt;p&gt;Hello &lt;strong&gt;world&lt;/strong&gt;&lt;/p&gt;',
-        ];
-        yield 'single quotes escaped' => [
-            "Hello 'world'",
-            'Hello &#039;world&#039;',
-        ];
-        yield 'double quotes escaped' => [
-            'Hello "world"',
-            'Hello &quot;world&quot;',
-        ];
-        yield 'ampersand escaped' => [
-            'A & B',
-            'A &amp; B',
-        ];
-        yield 'plain text unchanged' => [
-            'Just plain text',
-            'Just plain text',
-        ];
+        yield 'HTML tags preserved' => ['<p>Hello <strong>world</strong></p>'];
+        yield 'single quotes preserved' => ["Hello 'world'"];
+        yield 'double quotes preserved' => ['Hello "world"'];
+        yield 'ampersand preserved' => ['A & B'];
+        yield 'plain text unchanged' => ['Just plain text'];
     }
 
     #[Test]
@@ -211,7 +196,7 @@ final class CompleteResponseTest extends TestCase
     }
 
     #[Test]
-    public function successEscapesSpecialCharactersInFinishReason(): void
+    public function successPreservesRawFinishReason(): void
     {
         $usage = new UsageStatistics(10, 20, 30);
 
@@ -225,11 +210,11 @@ final class CompleteResponseTest extends TestCase
 
         $response = CompleteResponse::success($completionResponse);
 
-        $this->assertSame('stop&lt;script&gt;', $response->finishReason);
+        $this->assertSame('stop<script>', $response->finishReason);
     }
 
     #[Test]
-    public function successEscapesSpecialCharactersInModelAndFinishReason(): void
+    public function successPreservesRawModelAndFinishReason(): void
     {
         $usage = new UsageStatistics(10, 20, 30);
 
@@ -243,8 +228,8 @@ final class CompleteResponseTest extends TestCase
 
         $response = CompleteResponse::success($completionResponse);
 
-        $this->assertSame('model&#039;s-name', $response->model);
-        $this->assertSame('it&#039;s done', $response->finishReason);
+        $this->assertSame("model's-name", $response->model);
+        $this->assertSame("it's done", $response->finishReason);
     }
 
     private function createCompletionResponse(


### PR DESCRIPTION
## Summary

Remove redundant `htmlspecialchars()` encoding from all JSON API responses. JSON encoding (`json_encode`) inherently prevents XSS — content is transmitted as data, not rendered markup. The frontend already sanitizes via `DOMParser` before DOM insertion.

The old pattern created an unnecessary encode→decode roundtrip:
1. Server: `htmlspecialchars()` escapes `<`, `>`, `&`, `'`, `"`
2. Frontend: `_decodeEntities()` reverses the escaping via a hidden textarea
3. Frontend: `_sanitizeHtml()` sanitizes before DOM insertion

Now the flow is simply:
1. Server: returns raw content in JSON
2. Frontend: `_sanitizeHtml()` sanitizes before DOM insertion

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

<!-- No specific issue — found during code review -->

## Checklist

- [x] I have run `make lint` and it passes
- [x] I have run `make test` and all tests pass
- [ ] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature works
- [x] My code follows the project's code style (PSR-12)
- [ ] I have updated CHANGELOG.md if this is a user-facing change

## Test Plan

- 388 PHP unit tests pass (including updated assertions for raw content)
- 122 JS tests pass (including removal of `_decodeEntities`)
- Verify in browser: open cowriter dialog, run a completion, confirm content renders correctly (HTML tags in LLM responses should appear as-is in CKEditor, not as escaped entities)

## Files Changed

| File | Change |
|------|--------|
| `Classes/Controller/AjaxController.php` | Remove `htmlspecialchars()` from chat, stream, tasks responses |
| `Classes/Domain/DTO/CompleteResponse.php` | Remove `htmlspecialchars()` from `success()` factory |
| `Resources/Public/JavaScript/Ckeditor/CowriterDialog.js` | Remove `_decodeEntities()` method and usage |
| `Tests/Unit/Controller/AjaxControllerTest.php` | Expect raw content in assertions |
| `Tests/Unit/Domain/DTO/CompleteResponseTest.php` | Expect raw content in assertions |
| `Tests/E2E/CowriterWorkflowTest.php` | Expect raw content in assertions |