### PR TITLE
feat: add vision, translation, and template endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,34 +58,58 @@ ddev install-v14
 
 ```
 t3_cowriter/
-├── Classes/Controller/         # PHP AJAX endpoints (nr-llm integration)
-├── Configuration/              # TYPO3 configuration
-│   ├── Backend/AjaxRoutes.php  # AJAX route definitions
-│   ├── RTE/Cowriter.yaml       # CKEditor plugin registration
-│   └── Services.yaml           # DI container
-├── Resources/Public/JavaScript/ # CKEditor plugin
-│   └── Ckeditor/
-│       ├── AIService.js        # Frontend API client
-│       └── cowriter.js         # CKEditor integration
-└── Documentation/              # RST documentation
+├── Classes/
+│   ├── Controller/
+│   │   ├── AjaxController.php       # Main chat/complete/stream endpoints
+│   │   ├── VisionController.php     # Image analysis (alt text)
+│   │   ├── TranslationController.php # Content translation
+│   │   ├── TemplateController.php   # Prompt template listing
+│   │   └── ToolController.php       # LLM function calling
+│   ├── Domain/DTO/                  # Request/response DTOs
+│   ├── Tools/ContentQueryTool.php   # Tool definition for TYPO3 queries
+│   └── Service/                     # Rate limiting, context assembly
+├── Configuration/
+│   ├── Backend/AjaxRoutes.php       # 11 AJAX route definitions
+│   ├── RTE/Cowriter.yaml            # CKEditor toolbar configuration
+│   └── Services.yaml                # DI container
+├── Resources/Public/JavaScript/Ckeditor/
+│   ├── AIService.js                 # Frontend API client (all endpoints)
+│   ├── cowriter.js                  # CKEditor plugin (4 toolbar items)
+│   ├── CowriterDialog.js            # Task dialog UI
+│   └── UrlLoader.js                 # CSP-compliant URL injection
+└── Documentation/                   # RST documentation
 ```
 
 ### Data Flow
 
 ```
-CKEditor → AIService.js → TYPO3 AJAX → AjaxController → nr-llm → AI Provider
+CKEditor Toolbar
+  ├─ cowriter         → CowriterDialog → AIService.js → AjaxController
+  ├─ cowriterVision   → AIService.js ─────────────────→ VisionController
+  ├─ cowriterTranslate→ AIService.js ─────────────────→ TranslationController
+  ├─ cowriterTemplates→ AIService.js ─────────────────→ TemplateController
+  └─ (tool calling)   → AIService.js ─────────────────→ ToolController
                                                               ↓
-CKEditor ← Response ← TYPO3 AJAX ← AjaxController ← nr-llm ← Response
+                                                   LlmServiceManagerInterface
+                                                              ↓
+                                                        nr-llm Provider → AI API
 ```
 
 ### AJAX Routes
 
-| Route | Path | Method | Purpose |
-|-------|------|--------|---------|
-| `tx_cowriter_chat` | `/cowriter/chat` | `chatAction` | Chat completion with message array (stateless) |
-| `tx_cowriter_complete` | `/cowriter/complete` | `completeAction` | Single prompt completion |
-| `tx_cowriter_stream` | `/cowriter/stream` | `streamAction` | Streaming completion via SSE |
-| `tx_cowriter_configurations` | `/cowriter/configurations` | `getConfigurationsAction` | List available LLM configurations |
+| Route | Path | Controller | Purpose |
+|-------|------|------------|---------|
+| `tx_cowriter_chat` | `/cowriter/chat` | `AjaxController::chatAction` | Chat completion (stateless) |
+| `tx_cowriter_complete` | `/cowriter/complete` | `AjaxController::completeAction` | Single prompt completion |
+| `tx_cowriter_stream` | `/cowriter/stream` | `AjaxController::streamAction` | Streaming via SSE |
+| `tx_cowriter_configurations` | `/cowriter/configurations` | `AjaxController::getConfigurationsAction` | List LLM configurations |
+| `tx_cowriter_tasks` | `/cowriter/tasks` | `AjaxController::getTasksAction` | List available tasks |
+| `tx_cowriter_task_execute` | `/cowriter/task-execute` | `AjaxController::executeTaskAction` | Execute a task |
+| `tx_cowriter_context` | `/cowriter/context` | `AjaxController::getContextAction` | Context preview |
+| `tx_cowriter_vision` | `/cowriter/vision` | `VisionController::analyzeAction` | Image alt text generation |
+| `tx_cowriter_translate` | `/cowriter/translate` | `TranslationController::translateAction` | Content translation |
+| `tx_cowriter_templates` | `/cowriter/templates` | `TemplateController::listAction` | Prompt template listing |
+| `tx_cowriter_tools` | `/cowriter/tools` | `ToolController::executeAction` | LLM tool/function calling |
 
 ### Key Dependencies
 

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -27,7 +27,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
-use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\Response;
@@ -42,7 +41,6 @@ use TYPO3\CMS\Core\Http\Stream;
  * Returns raw data in JSON responses — no server-side HTML escaping.
  * The frontend sanitizes content via DOMParser before DOM insertion.
  */
-#[AsController]
 final readonly class AjaxController
 {
     /**

--- a/Classes/Controller/TemplateController.php
+++ b/Classes/Controller/TemplateController.php
@@ -63,20 +63,40 @@ final readonly class TemplateController
                 ];
             }
 
-            return new JsonResponse([
+            return $this->jsonResponseWithRateLimitHeaders([
                 'success'   => true,
                 'templates' => $result,
-            ]);
+            ], $rateLimitResult);
         } catch (Throwable $e) {
             $this->logger->error('Failed to list prompt templates', [
                 'exception' => $e->getMessage(),
             ]);
 
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Failed to load templates.'],
+                $rateLimitResult,
                 500,
             );
         }
+    }
+
+    /**
+     * Create JSON response with rate limit headers.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function jsonResponseWithRateLimitHeaders(
+        array $data,
+        RateLimitResult $rateLimitResult,
+        int $statusCode = 200,
+    ): JsonResponse {
+        $response = new JsonResponse($data, $statusCode);
+
+        foreach ($rateLimitResult->getHeaders() as $name => $value) {
+            $response = $response->withAddedHeader($name, $value);
+        }
+
+        return $response;
     }
 
     private function rateLimitedResponse(RateLimitResult $result): JsonResponse

--- a/Classes/Controller/TemplateController.php
+++ b/Classes/Controller/TemplateController.php
@@ -11,10 +11,13 @@ namespace Netresearch\T3Cowriter\Controller;
 
 use Netresearch\NrLlm\Domain\Model\PromptTemplate;
 use Netresearch\NrLlm\Domain\Repository\PromptTemplateRepository;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\JsonResponse;
 
 /**
@@ -28,11 +31,21 @@ final readonly class TemplateController
 {
     public function __construct(
         private PromptTemplateRepository $templateRepository,
+        private RateLimiterInterface $rateLimiter,
+        private Context $context,
         private LoggerInterface $logger,
     ) {}
 
     public function listAction(ServerRequestInterface $request): ResponseInterface
     {
+        /** @var int|string $userId */
+        $userId          = $this->context->getPropertyFromAspect('backend.user', 'id', 0);
+        $rateLimitResult = $this->rateLimiter->checkLimit((string) $userId);
+
+        if (!$rateLimitResult->allowed) {
+            return $this->rateLimitedResponse($rateLimitResult);
+        }
+
         try {
             $templates = $this->templateRepository->findActive();
             $result    = [];
@@ -64,5 +77,19 @@ final readonly class TemplateController
                 500,
             );
         }
+    }
+
+    private function rateLimitedResponse(RateLimitResult $result): JsonResponse
+    {
+        $response = new JsonResponse(
+            ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
+            429,
+        );
+
+        foreach ($result->getHeaders() as $name => $value) {
+            $response = $response->withAddedHeader($name, $value);
+        }
+
+        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
     }
 }

--- a/Classes/Controller/TemplateController.php
+++ b/Classes/Controller/TemplateController.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Controller;
+
+use Netresearch\NrLlm\Domain\Model\PromptTemplate;
+use Netresearch\NrLlm\Domain\Repository\PromptTemplateRepository;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * AJAX controller for prompt template management.
+ *
+ * Exposes available prompt templates for the CKEditor cowriter dialog.
+ *
+ * @internal
+ */
+final readonly class TemplateController
+{
+    public function __construct(
+        private PromptTemplateRepository $templateRepository,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function listAction(ServerRequestInterface $request): ResponseInterface
+    {
+        try {
+            $templates = $this->templateRepository->findActive();
+            $result    = [];
+
+            foreach ($templates as $template) {
+                if (!$template instanceof PromptTemplate) {
+                    continue;
+                }
+
+                $result[] = [
+                    'identifier'  => $template->getIdentifier(),
+                    'name'        => $template->getTitle(),
+                    'description' => $template->getDescription() ?? '',
+                    'category'    => $template->getFeature(),
+                ];
+            }
+
+            return new JsonResponse([
+                'success'   => true,
+                'templates' => $result,
+            ]);
+        } catch (Throwable $e) {
+            $this->logger->error('Failed to list prompt templates', [
+                'exception' => $e->getMessage(),
+            ]);
+
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Failed to load templates.'],
+                500,
+            );
+        }
+    }
+}

--- a/Classes/Controller/ToolController.php
+++ b/Classes/Controller/ToolController.php
@@ -9,10 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\T3Cowriter\Controller;
 
+use JsonException;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\T3Cowriter\Domain\DTO\ToolRequest;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
 use Netresearch\T3Cowriter\Tools\ContentQueryTool;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -45,14 +47,17 @@ final readonly class ToolController
         $rateLimitResult = $this->rateLimiter->checkLimit((string) $userId);
 
         if (!$rateLimitResult->allowed) {
+            return $this->rateLimitedResponse($rateLimitResult);
+        }
+
+        $body = $this->parseJsonBody($request);
+        if ($body === null) {
             return new JsonResponse(
-                ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
-                429,
+                ['success' => false, 'error' => 'Invalid JSON in request body.'],
+                400,
             );
         }
 
-        /** @var array<string, mixed> $body */
-        $body        = (array) $request->getParsedBody();
         $toolRequest = ToolRequest::fromRequestBody($body);
 
         if ($toolRequest->prompt === '') {
@@ -63,7 +68,7 @@ final readonly class ToolController
         }
 
         try {
-            $tools = [ContentQueryTool::definition()];
+            $tools = $this->resolveTools($toolRequest->enabledTools);
 
             $messages = [
                 ['role' => 'user', 'content' => $toolRequest->prompt],
@@ -93,5 +98,76 @@ final readonly class ToolController
                 500,
             );
         }
+    }
+
+    /**
+     * Resolve enabled tools from request against the allow-list.
+     *
+     * Falls back to all available tools when no valid tools are requested.
+     *
+     * @param list<string> $enabledTools
+     *
+     * @return array<int, array{type: string, function: array{name: string, description: string, parameters: array<string, mixed>}}>
+     */
+    private function resolveTools(array $enabledTools): array
+    {
+        /** @var array<string, array{type: string, function: array{name: string, description: string, parameters: array<string, mixed>}}> $allTools */
+        $allTools = [
+            'contentQuery' => ContentQueryTool::definition(),
+        ];
+
+        if ($enabledTools === []) {
+            return array_values($allTools);
+        }
+
+        $resolved = [];
+        foreach ($enabledTools as $toolName) {
+            if (isset($allTools[$toolName])) {
+                $resolved[] = $allTools[$toolName];
+            }
+        }
+
+        return $resolved !== [] ? $resolved : array_values($allTools);
+    }
+
+    /**
+     * Parse JSON body from request, returning null on failure.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function parseJsonBody(ServerRequestInterface $request): ?array
+    {
+        $rawBody = (string) $request->getBody();
+        if ($rawBody === '') {
+            return [];
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    private function rateLimitedResponse(RateLimitResult $result): JsonResponse
+    {
+        $response = new JsonResponse(
+            ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
+            429,
+        );
+
+        foreach ($result->getHeaders() as $name => $value) {
+            $response = $response->withAddedHeader($name, $value);
+        }
+
+        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
     }
 }

--- a/Classes/Controller/ToolController.php
+++ b/Classes/Controller/ToolController.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Controller;
+
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\T3Cowriter\Domain\DTO\ToolRequest;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Tools\ContentQueryTool;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * AJAX controller for LLM tool calling via nr-llm.
+ *
+ * Enables structured function calling where the LLM can invoke
+ * predefined tools (e.g., content queries) during conversations.
+ *
+ * @internal
+ */
+final readonly class ToolController
+{
+    public function __construct(
+        private LlmServiceManagerInterface $llmServiceManager,
+        private RateLimiterInterface $rateLimiter,
+        private Context $context,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function executeAction(ServerRequestInterface $request): ResponseInterface
+    {
+        /** @var int|string $userId */
+        $userId          = $this->context->getPropertyFromAspect('backend.user', 'id', 0);
+        $rateLimitResult = $this->rateLimiter->checkLimit((string) $userId);
+
+        if (!$rateLimitResult->allowed) {
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
+                429,
+            );
+        }
+
+        /** @var array<string, mixed> $body */
+        $body        = (array) $request->getParsedBody();
+        $toolRequest = ToolRequest::fromRequestBody($body);
+
+        if ($toolRequest->prompt === '') {
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Missing prompt parameter.'],
+                400,
+            );
+        }
+
+        try {
+            $tools = [ContentQueryTool::definition()];
+
+            $messages = [
+                ['role' => 'user', 'content' => $toolRequest->prompt],
+            ];
+
+            $options  = ToolOptions::auto();
+            $response = $this->llmServiceManager->chatWithTools($messages, $tools, $options);
+
+            return new JsonResponse([
+                'success'      => true,
+                'content'      => $response->content,
+                'toolCalls'    => $response->toolCalls,
+                'finishReason' => $response->finishReason,
+                'usage'        => [
+                    'promptTokens'     => $response->usage->promptTokens,
+                    'completionTokens' => $response->usage->completionTokens,
+                    'totalTokens'      => $response->usage->totalTokens,
+                ],
+            ]);
+        } catch (Throwable $e) {
+            $this->logger->error('Tool execution failed', [
+                'exception' => $e->getMessage(),
+            ]);
+
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Tool execution failed. Please try again.'],
+                500,
+            );
+        }
+    }
+}

--- a/Classes/Controller/ToolController.php
+++ b/Classes/Controller/ToolController.php
@@ -52,17 +52,27 @@ final readonly class ToolController
 
         $body = $this->parseJsonBody($request);
         if ($body === null) {
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Invalid JSON in request body.'],
+                $rateLimitResult,
                 400,
             );
         }
 
         $toolRequest = ToolRequest::fromRequestBody($body);
 
+        if (!$toolRequest->isValid()) {
+            return $this->jsonResponseWithRateLimitHeaders(
+                ['success' => false, 'error' => 'Invalid request: fields exceed maximum length.'],
+                $rateLimitResult,
+                400,
+            );
+        }
+
         if ($toolRequest->prompt === '') {
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Missing prompt parameter.'],
+                $rateLimitResult,
                 400,
             );
         }
@@ -77,7 +87,7 @@ final readonly class ToolController
             $options  = ToolOptions::auto();
             $response = $this->llmServiceManager->chatWithTools($messages, $tools, $options);
 
-            return new JsonResponse([
+            return $this->jsonResponseWithRateLimitHeaders([
                 'success'      => true,
                 'content'      => $response->content,
                 'toolCalls'    => $response->toolCalls,
@@ -87,14 +97,15 @@ final readonly class ToolController
                     'completionTokens' => $response->usage->completionTokens,
                     'totalTokens'      => $response->usage->totalTokens,
                 ],
-            ]);
+            ], $rateLimitResult);
         } catch (Throwable $e) {
             $this->logger->error('Tool execution failed', [
                 'exception' => $e->getMessage(),
             ]);
 
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Tool execution failed. Please try again.'],
+                $rateLimitResult,
                 500,
             );
         }
@@ -113,7 +124,7 @@ final readonly class ToolController
     {
         /** @var array<string, array{type: string, function: array{name: string, description: string, parameters: array<string, mixed>}}> $allTools */
         $allTools = [
-            'contentQuery' => ContentQueryTool::definition(),
+            'query_content' => ContentQueryTool::definition(),
         ];
 
         if ($enabledTools === []) {
@@ -155,6 +166,25 @@ final readonly class ToolController
 
         /** @var array<string, mixed> $decoded */
         return $decoded;
+    }
+
+    /**
+     * Create JSON response with rate limit headers.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function jsonResponseWithRateLimitHeaders(
+        array $data,
+        RateLimitResult $rateLimitResult,
+        int $statusCode = 200,
+    ): JsonResponse {
+        $response = new JsonResponse($data, $statusCode);
+
+        foreach ($rateLimitResult->getHeaders() as $name => $value) {
+            $response = $response->withAddedHeader($name, $value);
+        }
+
+        return $response;
     }
 
     private function rateLimitedResponse(RateLimitResult $result): JsonResponse

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -48,8 +48,9 @@ final readonly class TranslationController
 
         $body = $this->parseJsonBody($request);
         if ($body === null) {
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Invalid JSON in request body.'],
+                $rateLimitResult,
                 400,
             );
         }
@@ -57,15 +58,17 @@ final readonly class TranslationController
         $translationRequest = TranslationRequest::fromRequestBody($body);
 
         if (!$translationRequest->isValid()) {
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Invalid request: fields exceed maximum length.'],
+                $rateLimitResult,
                 400,
             );
         }
 
         if ($translationRequest->text === '' || $translationRequest->targetLanguage === '') {
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Missing text or targetLanguage parameter.'],
+                $rateLimitResult,
                 400,
             );
         }
@@ -83,7 +86,7 @@ final readonly class TranslationController
                 $options,
             );
 
-            return new JsonResponse([
+            return $this->jsonResponseWithRateLimitHeaders([
                 'success'        => true,
                 'translation'    => $result->translation,
                 'sourceLanguage' => $result->sourceLanguage,
@@ -93,15 +96,16 @@ final readonly class TranslationController
                     'completionTokens' => $result->usage->completionTokens,
                     'totalTokens'      => $result->usage->totalTokens,
                 ],
-            ]);
+            ], $rateLimitResult);
         } catch (Throwable $e) {
             $this->logger->error('Translation failed', [
                 'exception'      => $e->getMessage(),
                 'targetLanguage' => $translationRequest->targetLanguage,
             ]);
 
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Translation failed. Please try again.'],
+                $rateLimitResult,
                 500,
             );
         }
@@ -132,6 +136,25 @@ final readonly class TranslationController
 
         /** @var array<string, mixed> $decoded */
         return $decoded;
+    }
+
+    /**
+     * Create JSON response with rate limit headers.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function jsonResponseWithRateLimitHeaders(
+        array $data,
+        RateLimitResult $rateLimitResult,
+        int $statusCode = 200,
+    ): JsonResponse {
+        $response = new JsonResponse($data, $statusCode);
+
+        foreach ($rateLimitResult->getHeaders() as $name => $value) {
+            $response = $response->withAddedHeader($name, $value);
+        }
+
+        return $response;
     }
 
     private function rateLimitedResponse(RateLimitResult $result): JsonResponse

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Controller;
+
+use Netresearch\NrLlm\Service\Feature\TranslationService;
+use Netresearch\NrLlm\Service\Option\TranslationOptions;
+use Netresearch\T3Cowriter\Domain\DTO\TranslationRequest;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * AJAX controller for content translation via nr-llm TranslationService.
+ *
+ * @internal
+ */
+final readonly class TranslationController
+{
+    public function __construct(
+        private TranslationService $translationService,
+        private RateLimiterInterface $rateLimiter,
+        private Context $context,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function translateAction(ServerRequestInterface $request): ResponseInterface
+    {
+        /** @var int|string $userId */
+        $userId          = $this->context->getPropertyFromAspect('backend.user', 'id', 0);
+        $rateLimitResult = $this->rateLimiter->checkLimit((string) $userId);
+
+        if (!$rateLimitResult->allowed) {
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
+                429,
+            );
+        }
+
+        /** @var array<string, mixed> $body */
+        $body               = (array) $request->getParsedBody();
+        $translationRequest = TranslationRequest::fromRequestBody($body);
+
+        if ($translationRequest->text === '' || $translationRequest->targetLanguage === '') {
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Missing text or targetLanguage parameter.'],
+                400,
+            );
+        }
+
+        try {
+            $options = new TranslationOptions(
+                formality: $translationRequest->formality,
+                domain: $translationRequest->domain,
+            );
+
+            $result = $this->translationService->translate(
+                $translationRequest->text,
+                $translationRequest->targetLanguage,
+                null,
+                $options,
+            );
+
+            return new JsonResponse([
+                'success'        => true,
+                'translation'    => $result->translation,
+                'sourceLanguage' => $result->sourceLanguage,
+                'confidence'     => $result->confidence,
+                'usage'          => [
+                    'promptTokens'     => $result->usage->promptTokens,
+                    'completionTokens' => $result->usage->completionTokens,
+                    'totalTokens'      => $result->usage->totalTokens,
+                ],
+            ]);
+        } catch (Throwable $e) {
+            $this->logger->error('Translation failed', [
+                'exception'      => $e->getMessage(),
+                'targetLanguage' => $translationRequest->targetLanguage,
+            ]);
+
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Translation failed. Please try again.'],
+                500,
+            );
+        }
+    }
+}

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -9,10 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\T3Cowriter\Controller;
 
+use JsonException;
 use Netresearch\NrLlm\Service\Feature\TranslationService;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
 use Netresearch\T3Cowriter\Domain\DTO\TranslationRequest;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
@@ -41,15 +43,25 @@ final readonly class TranslationController
         $rateLimitResult = $this->rateLimiter->checkLimit((string) $userId);
 
         if (!$rateLimitResult->allowed) {
+            return $this->rateLimitedResponse($rateLimitResult);
+        }
+
+        $body = $this->parseJsonBody($request);
+        if ($body === null) {
             return new JsonResponse(
-                ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
-                429,
+                ['success' => false, 'error' => 'Invalid JSON in request body.'],
+                400,
             );
         }
 
-        /** @var array<string, mixed> $body */
-        $body               = (array) $request->getParsedBody();
         $translationRequest = TranslationRequest::fromRequestBody($body);
+
+        if (!$translationRequest->isValid()) {
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Invalid request: fields exceed maximum length.'],
+                400,
+            );
+        }
 
         if ($translationRequest->text === '' || $translationRequest->targetLanguage === '') {
             return new JsonResponse(
@@ -67,7 +79,7 @@ final readonly class TranslationController
             $result = $this->translationService->translate(
                 $translationRequest->text,
                 $translationRequest->targetLanguage,
-                null,
+                $translationRequest->configuration,
                 $options,
             );
 
@@ -93,5 +105,46 @@ final readonly class TranslationController
                 500,
             );
         }
+    }
+
+    /**
+     * Parse JSON body from request, returning null on failure.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function parseJsonBody(ServerRequestInterface $request): ?array
+    {
+        $rawBody = (string) $request->getBody();
+        if ($rawBody === '') {
+            return [];
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    private function rateLimitedResponse(RateLimitResult $result): JsonResponse
+    {
+        $response = new JsonResponse(
+            ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
+            429,
+        );
+
+        foreach ($result->getHeaders() as $name => $value) {
+            $response = $response->withAddedHeader($name, $value);
+        }
+
+        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
     }
 }

--- a/Classes/Controller/VisionController.php
+++ b/Classes/Controller/VisionController.php
@@ -9,10 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\T3Cowriter\Controller;
 
+use JsonException;
 use Netresearch\NrLlm\Service\Feature\VisionService;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\T3Cowriter\Domain\DTO\VisionRequest;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
@@ -41,15 +43,25 @@ final readonly class VisionController
         $rateLimitResult = $this->rateLimiter->checkLimit((string) $userId);
 
         if (!$rateLimitResult->allowed) {
+            return $this->rateLimitedResponse($rateLimitResult);
+        }
+
+        $body = $this->parseJsonBody($request);
+        if ($body === null) {
             return new JsonResponse(
-                ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
-                429,
+                ['success' => false, 'error' => 'Invalid JSON in request body.'],
+                400,
             );
         }
 
-        /** @var array<string, mixed> $body */
-        $body          = (array) $request->getParsedBody();
         $visionRequest = VisionRequest::fromRequestBody($body);
+
+        if (!$visionRequest->isValid()) {
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Invalid request: fields exceed maximum length.'],
+                400,
+            );
+        }
 
         if ($visionRequest->imageUrl === '') {
             return new JsonResponse(
@@ -88,5 +100,46 @@ final readonly class VisionController
                 500,
             );
         }
+    }
+
+    /**
+     * Parse JSON body from request, returning null on failure.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function parseJsonBody(ServerRequestInterface $request): ?array
+    {
+        $rawBody = (string) $request->getBody();
+        if ($rawBody === '') {
+            return [];
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    private function rateLimitedResponse(RateLimitResult $result): JsonResponse
+    {
+        $response = new JsonResponse(
+            ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
+            429,
+        );
+
+        foreach ($result->getHeaders() as $name => $value) {
+            $response = $response->withAddedHeader($name, $value);
+        }
+
+        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
     }
 }

--- a/Classes/Controller/VisionController.php
+++ b/Classes/Controller/VisionController.php
@@ -48,8 +48,9 @@ final readonly class VisionController
 
         $body = $this->parseJsonBody($request);
         if ($body === null) {
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Invalid JSON in request body.'],
+                $rateLimitResult,
                 400,
             );
         }
@@ -57,15 +58,17 @@ final readonly class VisionController
         $visionRequest = VisionRequest::fromRequestBody($body);
 
         if (!$visionRequest->isValid()) {
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Invalid request: fields exceed maximum length.'],
+                $rateLimitResult,
                 400,
             );
         }
 
         if ($visionRequest->imageUrl === '') {
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Missing or empty imageUrl parameter.'],
+                $rateLimitResult,
                 400,
             );
         }
@@ -78,7 +81,7 @@ final readonly class VisionController
                 $options,
             );
 
-            return new JsonResponse([
+            return $this->jsonResponseWithRateLimitHeaders([
                 'success'    => true,
                 'altText'    => $response->description,
                 'model'      => $response->model,
@@ -88,15 +91,16 @@ final readonly class VisionController
                     'completionTokens' => $response->usage->completionTokens,
                     'totalTokens'      => $response->usage->totalTokens,
                 ],
-            ]);
+            ], $rateLimitResult);
         } catch (Throwable $e) {
             $this->logger->error('Vision analysis failed', [
                 'exception' => $e->getMessage(),
                 'imageUrl'  => substr($visionRequest->imageUrl, 0, 100),
             ]);
 
-            return new JsonResponse(
+            return $this->jsonResponseWithRateLimitHeaders(
                 ['success' => false, 'error' => 'Image analysis failed. Please try again.'],
+                $rateLimitResult,
                 500,
             );
         }
@@ -127,6 +131,25 @@ final readonly class VisionController
 
         /** @var array<string, mixed> $decoded */
         return $decoded;
+    }
+
+    /**
+     * Create JSON response with rate limit headers.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function jsonResponseWithRateLimitHeaders(
+        array $data,
+        RateLimitResult $rateLimitResult,
+        int $statusCode = 200,
+    ): JsonResponse {
+        $response = new JsonResponse($data, $statusCode);
+
+        foreach ($rateLimitResult->getHeaders() as $name => $value) {
+            $response = $response->withAddedHeader($name, $value);
+        }
+
+        return $response;
     }
 
     private function rateLimitedResponse(RateLimitResult $result): JsonResponse

--- a/Classes/Controller/VisionController.php
+++ b/Classes/Controller/VisionController.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Controller;
+
+use Netresearch\NrLlm\Service\Feature\VisionService;
+use Netresearch\NrLlm\Service\Option\VisionOptions;
+use Netresearch\T3Cowriter\Domain\DTO\VisionRequest;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * AJAX controller for image analysis via nr-llm VisionService.
+ *
+ * @internal
+ */
+final readonly class VisionController
+{
+    public function __construct(
+        private VisionService $visionService,
+        private RateLimiterInterface $rateLimiter,
+        private Context $context,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function analyzeAction(ServerRequestInterface $request): ResponseInterface
+    {
+        /** @var int|string $userId */
+        $userId          = $this->context->getPropertyFromAspect('backend.user', 'id', 0);
+        $rateLimitResult = $this->rateLimiter->checkLimit((string) $userId);
+
+        if (!$rateLimitResult->allowed) {
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
+                429,
+            );
+        }
+
+        /** @var array<string, mixed> $body */
+        $body          = (array) $request->getParsedBody();
+        $visionRequest = VisionRequest::fromRequestBody($body);
+
+        if ($visionRequest->imageUrl === '') {
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Missing or empty imageUrl parameter.'],
+                400,
+            );
+        }
+
+        try {
+            $options  = new VisionOptions();
+            $response = $this->visionService->analyzeImageFull(
+                $visionRequest->imageUrl,
+                $visionRequest->prompt,
+                $options,
+            );
+
+            return new JsonResponse([
+                'success'    => true,
+                'altText'    => $response->description,
+                'model'      => $response->model,
+                'confidence' => $response->confidence,
+                'usage'      => [
+                    'promptTokens'     => $response->usage->promptTokens,
+                    'completionTokens' => $response->usage->completionTokens,
+                    'totalTokens'      => $response->usage->totalTokens,
+                ],
+            ]);
+        } catch (Throwable $e) {
+            $this->logger->error('Vision analysis failed', [
+                'exception' => $e->getMessage(),
+                'imageUrl'  => substr($visionRequest->imageUrl, 0, 100),
+            ]);
+
+            return new JsonResponse(
+                ['success' => false, 'error' => 'Image analysis failed. Please try again.'],
+                500,
+            );
+        }
+    }
+}

--- a/Classes/Domain/DTO/CompleteResponse.php
+++ b/Classes/Domain/DTO/CompleteResponse.php
@@ -104,15 +104,17 @@ final readonly class CompleteResponse implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        $data = ['success' => $this->success];
+        $data = [
+            'success'      => $this->success,
+            'wasTruncated' => $this->wasTruncated,
+            'wasFiltered'  => $this->wasFiltered,
+        ];
 
         if ($this->success) {
             $data['content']      = $this->content;
             $data['model']        = $this->model;
             $data['finishReason'] = $this->finishReason;
             $data['usage']        = $this->usage?->jsonSerialize();
-            $data['wasTruncated'] = $this->wasTruncated;
-            $data['wasFiltered']  = $this->wasFiltered;
         } else {
             $data['error'] = $this->error;
             if ($this->retryAfter !== null) {

--- a/Classes/Domain/DTO/CompleteResponse.php
+++ b/Classes/Domain/DTO/CompleteResponse.php
@@ -28,6 +28,8 @@ final readonly class CompleteResponse implements JsonSerializable
         public ?string $model,
         public ?string $finishReason,
         public ?UsageData $usage,
+        public bool $wasTruncated,
+        public bool $wasFiltered,
         public ?string $error,
         public ?int $retryAfter,
     ) {}
@@ -46,6 +48,8 @@ final readonly class CompleteResponse implements JsonSerializable
             model: $response->model ?? '',
             finishReason: $response->finishReason ?? '',
             usage: UsageData::fromUsageStatistics($response->usage),
+            wasTruncated: $response->wasTruncated(),
+            wasFiltered: $response->wasFiltered(),
             error: null,
             retryAfter: null,
         );
@@ -62,6 +66,8 @@ final readonly class CompleteResponse implements JsonSerializable
             model: null,
             finishReason: null,
             usage: null,
+            wasTruncated: false,
+            wasFiltered: false,
             error: $message,
             retryAfter: null,
         );
@@ -84,6 +90,8 @@ final readonly class CompleteResponse implements JsonSerializable
             model: null,
             finishReason: null,
             usage: null,
+            wasTruncated: false,
+            wasFiltered: false,
             error: 'Rate limit exceeded. Please try again later.',
             retryAfter: $retryAfter,
         );
@@ -103,6 +111,8 @@ final readonly class CompleteResponse implements JsonSerializable
             $data['model']        = $this->model;
             $data['finishReason'] = $this->finishReason;
             $data['usage']        = $this->usage?->jsonSerialize();
+            $data['wasTruncated'] = $this->wasTruncated;
+            $data['wasFiltered']  = $this->wasFiltered;
         } else {
             $data['error'] = $this->error;
             if ($this->retryAfter !== null) {

--- a/Classes/Domain/DTO/ToolRequest.php
+++ b/Classes/Domain/DTO/ToolRequest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Domain\DTO;
+
+/**
+ * Request DTO for tool calling AJAX endpoint.
+ *
+ * @internal
+ */
+final readonly class ToolRequest
+{
+    /**
+     * @param list<string> $enabledTools
+     */
+    public function __construct(
+        public string $prompt,
+        public array $enabledTools = [],
+        public ?string $configuration = null,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    public static function fromRequestBody(array $body): self
+    {
+        return new self(
+            prompt: trim(self::extractString($body, 'prompt')),
+            enabledTools: self::extractStringList($body, 'tools'),
+            configuration: self::extractNullableString($body, 'configuration'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function extractString(array $data, string $key, string $default = ''): string
+    {
+        $value = $data[$key] ?? $default;
+
+        return is_scalar($value) ? (string) $value : $default;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function extractNullableString(array $data, string $key): ?string
+    {
+        $value = $data[$key] ?? null;
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return is_scalar($value) ? trim((string) $value) : null;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return list<string>
+     */
+    private static function extractStringList(array $data, string $key): array
+    {
+        $value = $data[$key] ?? [];
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($value as $item) {
+            if (is_scalar($item)) {
+                $trimmed = trim((string) $item);
+                if ($trimmed !== '') {
+                    $result[] = $trimmed;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/Classes/Domain/DTO/ToolRequest.php
+++ b/Classes/Domain/DTO/ToolRequest.php
@@ -24,7 +24,6 @@ final readonly class ToolRequest
     public function __construct(
         public string $prompt,
         public array $enabledTools = [],
-        public ?string $configuration = null,
     ) {}
 
     /**
@@ -43,7 +42,6 @@ final readonly class ToolRequest
         return new self(
             prompt: trim(self::extractString($body, 'prompt')),
             enabledTools: self::extractStringList($body, 'tools'),
-            configuration: self::extractNullableString($body, 'configuration'),
         );
     }
 
@@ -55,19 +53,6 @@ final readonly class ToolRequest
         $value = $data[$key] ?? $default;
 
         return is_scalar($value) ? (string) $value : $default;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private static function extractNullableString(array $data, string $key): ?string
-    {
-        $value = $data[$key] ?? null;
-        if ($value === null || $value === '') {
-            return null;
-        }
-
-        return is_scalar($value) ? trim((string) $value) : null;
     }
 
     /**

--- a/Classes/Domain/DTO/ToolRequest.php
+++ b/Classes/Domain/DTO/ToolRequest.php
@@ -16,6 +16,8 @@ namespace Netresearch\T3Cowriter\Domain\DTO;
  */
 final readonly class ToolRequest
 {
+    private const MAX_FIELD_LENGTH = 32768;
+
     /**
      * @param list<string> $enabledTools
      */
@@ -24,6 +26,14 @@ final readonly class ToolRequest
         public array $enabledTools = [],
         public ?string $configuration = null,
     ) {}
+
+    /**
+     * Validate field lengths to prevent resource exhaustion.
+     */
+    public function isValid(): bool
+    {
+        return mb_strlen($this->prompt) <= self::MAX_FIELD_LENGTH;
+    }
 
     /**
      * @param array<string, mixed> $body

--- a/Classes/Domain/DTO/TranslationRequest.php
+++ b/Classes/Domain/DTO/TranslationRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Domain\DTO;
+
+/**
+ * Request DTO for translation AJAX endpoint.
+ *
+ * @internal
+ */
+final readonly class TranslationRequest
+{
+    public function __construct(
+        public string $text,
+        public string $targetLanguage,
+        public string $formality = 'default',
+        public string $domain = 'general',
+        public ?string $configuration = null,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    public static function fromRequestBody(array $body): self
+    {
+        return new self(
+            text: trim(self::extractString($body, 'text')),
+            targetLanguage: trim(self::extractString($body, 'targetLanguage')),
+            formality: trim(self::extractString($body, 'formality', 'default')),
+            domain: trim(self::extractString($body, 'domain', 'general')),
+            configuration: self::extractNullableString($body, 'configuration'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function extractString(array $data, string $key, string $default = ''): string
+    {
+        $value = $data[$key] ?? $default;
+
+        return is_scalar($value) ? (string) $value : $default;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function extractNullableString(array $data, string $key): ?string
+    {
+        $value = $data[$key] ?? null;
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return is_scalar($value) ? trim((string) $value) : null;
+    }
+}

--- a/Classes/Domain/DTO/TranslationRequest.php
+++ b/Classes/Domain/DTO/TranslationRequest.php
@@ -32,7 +32,9 @@ final readonly class TranslationRequest
     public function isValid(): bool
     {
         return mb_strlen($this->text) <= self::MAX_FIELD_LENGTH
-            && mb_strlen($this->targetLanguage) <= 10;
+            && mb_strlen($this->targetLanguage) <= 10
+            && mb_strlen($this->formality) <= 50
+            && mb_strlen($this->domain) <= 100;
     }
 
     /**

--- a/Classes/Domain/DTO/TranslationRequest.php
+++ b/Classes/Domain/DTO/TranslationRequest.php
@@ -16,6 +16,8 @@ namespace Netresearch\T3Cowriter\Domain\DTO;
  */
 final readonly class TranslationRequest
 {
+    private const MAX_FIELD_LENGTH = 32768;
+
     public function __construct(
         public string $text,
         public string $targetLanguage,
@@ -23,6 +25,15 @@ final readonly class TranslationRequest
         public string $domain = 'general',
         public ?string $configuration = null,
     ) {}
+
+    /**
+     * Validate field lengths to prevent resource exhaustion.
+     */
+    public function isValid(): bool
+    {
+        return mb_strlen($this->text) <= self::MAX_FIELD_LENGTH
+            && mb_strlen($this->targetLanguage) <= 10;
+    }
 
     /**
      * @param array<string, mixed> $body

--- a/Classes/Domain/DTO/VisionRequest.php
+++ b/Classes/Domain/DTO/VisionRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Domain\DTO;
+
+/**
+ * Request DTO for vision/image analysis AJAX endpoint.
+ *
+ * @internal
+ */
+final readonly class VisionRequest
+{
+    private const DEFAULT_PROMPT = 'Generate a concise, descriptive alt text for this image.';
+
+    public function __construct(
+        public string $imageUrl,
+        public string $prompt = self::DEFAULT_PROMPT,
+        public ?string $configuration = null,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    public static function fromRequestBody(array $body): self
+    {
+        return new self(
+            imageUrl: trim(self::extractString($body, 'imageUrl')),
+            prompt: trim(self::extractString($body, 'prompt', self::DEFAULT_PROMPT)),
+            configuration: self::extractNullableString($body, 'configuration'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function extractString(array $data, string $key, string $default = ''): string
+    {
+        $value = $data[$key] ?? $default;
+
+        return is_scalar($value) ? (string) $value : $default;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function extractNullableString(array $data, string $key): ?string
+    {
+        $value = $data[$key] ?? null;
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return is_scalar($value) ? trim((string) $value) : null;
+    }
+}

--- a/Classes/Domain/DTO/VisionRequest.php
+++ b/Classes/Domain/DTO/VisionRequest.php
@@ -18,11 +18,22 @@ final readonly class VisionRequest
 {
     private const DEFAULT_PROMPT = 'Generate a concise, descriptive alt text for this image.';
 
+    private const MAX_FIELD_LENGTH = 32768;
+
     public function __construct(
         public string $imageUrl,
         public string $prompt = self::DEFAULT_PROMPT,
         public ?string $configuration = null,
     ) {}
+
+    /**
+     * Validate field lengths to prevent resource exhaustion.
+     */
+    public function isValid(): bool
+    {
+        return mb_strlen($this->imageUrl) <= self::MAX_FIELD_LENGTH
+            && mb_strlen($this->prompt) <= self::MAX_FIELD_LENGTH;
+    }
 
     /**
      * @param array<string, mixed> $body

--- a/Classes/Domain/DTO/VisionRequest.php
+++ b/Classes/Domain/DTO/VisionRequest.php
@@ -23,7 +23,6 @@ final readonly class VisionRequest
     public function __construct(
         public string $imageUrl,
         public string $prompt = self::DEFAULT_PROMPT,
-        public ?string $configuration = null,
     ) {}
 
     /**
@@ -43,7 +42,6 @@ final readonly class VisionRequest
         return new self(
             imageUrl: trim(self::extractString($body, 'imageUrl')),
             prompt: trim(self::extractString($body, 'prompt', self::DEFAULT_PROMPT)),
-            configuration: self::extractNullableString($body, 'configuration'),
         );
     }
 
@@ -55,18 +53,5 @@ final readonly class VisionRequest
         $value = $data[$key] ?? $default;
 
         return is_scalar($value) ? (string) $value : $default;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private static function extractNullableString(array $data, string $key): ?string
-    {
-        $value = $data[$key] ?? null;
-        if ($value === null || $value === '') {
-            return null;
-        }
-
-        return is_scalar($value) ? trim((string) $value) : null;
     }
 }

--- a/Classes/EventListener/InjectAjaxUrlsListener.php
+++ b/Classes/EventListener/InjectAjaxUrlsListener.php
@@ -85,6 +85,12 @@ final readonly class InjectAjaxUrlsListener
                 ->buildUriFromRoute('ajax_tx_cowriter_task_execute'),
             'tx_cowriter_context' => (string) $this->backendUriBuilder
                 ->buildUriFromRoute('ajax_tx_cowriter_context'),
+            'tx_cowriter_vision' => (string) $this->backendUriBuilder
+                ->buildUriFromRoute('ajax_tx_cowriter_vision'),
+            'tx_cowriter_translate' => (string) $this->backendUriBuilder
+                ->buildUriFromRoute('ajax_tx_cowriter_translate'),
+            'tx_cowriter_templates' => (string) $this->backendUriBuilder
+                ->buildUriFromRoute('ajax_tx_cowriter_templates'),
         ];
 
         return json_encode($urls, JSON_THROW_ON_ERROR);

--- a/Classes/EventListener/InjectAjaxUrlsListener.php
+++ b/Classes/EventListener/InjectAjaxUrlsListener.php
@@ -91,6 +91,8 @@ final readonly class InjectAjaxUrlsListener
                 ->buildUriFromRoute('ajax_tx_cowriter_translate'),
             'tx_cowriter_templates' => (string) $this->backendUriBuilder
                 ->buildUriFromRoute('ajax_tx_cowriter_templates'),
+            'tx_cowriter_tools' => (string) $this->backendUriBuilder
+                ->buildUriFromRoute('ajax_tx_cowriter_tools'),
         ];
 
         return json_encode($urls, JSON_THROW_ON_ERROR);

--- a/Classes/Tools/ContentQueryTool.php
+++ b/Classes/Tools/ContentQueryTool.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tools;
+
+/**
+ * Tool definition for LLM function calling.
+ *
+ * Provides a structured tool that allows the LLM to query
+ * TYPO3 page and content element metadata during conversations.
+ *
+ * @internal
+ */
+final class ContentQueryTool
+{
+    /**
+     * Get the tool definition for the LLM API.
+     *
+     * @return array{type: string, function: array{name: string, description: string, parameters: array<string, mixed>}}
+     */
+    public static function definition(): array
+    {
+        return [
+            'type'     => 'function',
+            'function' => [
+                'name'        => 'query_content',
+                'description' => 'Query TYPO3 content elements by type or page. Returns metadata about content elements on a specific page.',
+                'parameters'  => [
+                    'type'       => 'object',
+                    'properties' => [
+                        'pageId' => [
+                            'type'        => 'integer',
+                            'description' => 'TYPO3 page UID to query content from',
+                        ],
+                        'contentType' => [
+                            'type'        => 'string',
+                            'description' => 'Content element type filter (e.g., text, textmedia, header)',
+                        ],
+                    ],
+                    'required' => ['pageId'],
+                ],
+            ],
+        ];
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 use Netresearch\T3Cowriter\Controller\AjaxController;
 use Netresearch\T3Cowriter\Controller\TemplateController;
+use Netresearch\T3Cowriter\Controller\ToolController;
 use Netresearch\T3Cowriter\Controller\TranslationController;
 use Netresearch\T3Cowriter\Controller\VisionController;
 
@@ -61,5 +62,9 @@ return [
     'tx_cowriter_templates' => [
         'path'   => '/cowriter/templates',
         'target' => TemplateController::class . '::listAction',
+    ],
+    'tx_cowriter_tools' => [
+        'path'   => '/cowriter/tools',
+        'target' => ToolController::class . '::executeAction',
     ],
 ];

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -8,6 +8,9 @@
 declare(strict_types=1);
 
 use Netresearch\T3Cowriter\Controller\AjaxController;
+use Netresearch\T3Cowriter\Controller\TemplateController;
+use Netresearch\T3Cowriter\Controller\TranslationController;
+use Netresearch\T3Cowriter\Controller\VisionController;
 
 /**
  * AJAX route definitions for backend LLM interactions.
@@ -46,5 +49,17 @@ return [
     'tx_cowriter_context' => [
         'path'   => '/cowriter/context',
         'target' => AjaxController::class . '::getContextAction',
+    ],
+    'tx_cowriter_vision' => [
+        'path'   => '/cowriter/vision',
+        'target' => VisionController::class . '::analyzeAction',
+    ],
+    'tx_cowriter_translate' => [
+        'path'   => '/cowriter/translate',
+        'target' => TranslationController::class . '::translateAction',
+    ],
+    'tx_cowriter_templates' => [
+        'path'   => '/cowriter/templates',
+        'target' => TemplateController::class . '::listAction',
     ],
 ];

--- a/Configuration/RTE/Cowriter.yaml
+++ b/Configuration/RTE/Cowriter.yaml
@@ -43,6 +43,9 @@ editor:
         - fontColor
         - '|'
         - cowriter
+        - cowriterVision
+        - cowriterTranslate
+        - cowriterTemplates
 
     heading:
       options:

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -32,3 +32,6 @@ services:
 
   Netresearch\T3Cowriter\Controller\TemplateController:
     public: true
+
+  Netresearch\T3Cowriter\Controller\ToolController:
+    public: true

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -23,3 +23,12 @@ services:
 
   Netresearch\T3Cowriter\Controller\AjaxController:
     public: true
+
+  Netresearch\T3Cowriter\Controller\VisionController:
+    public: true
+
+  Netresearch\T3Cowriter\Controller\TranslationController:
+    public: true
+
+  Netresearch\T3Cowriter\Controller\TemplateController:
+    public: true

--- a/Documentation/Api/Index.rst
+++ b/Documentation/Api/Index.rst
@@ -1,0 +1,287 @@
+..  include:: /Includes.rst.txt
+
+.. _api:
+
+=============
+API Reference
+=============
+
+The Cowriter extension exposes several AJAX endpoints under
+``/typo3/ajax/cowriter/``. All endpoints require an authenticated
+backend session.
+
+.. contents::
+   :local:
+
+Common response format
+======================
+
+All endpoints return JSON with a ``success`` boolean. On error,
+an ``error`` string describes the problem.
+
+Rate limit headers are included on every response:
+
+*   ``X-RateLimit-Limit`` — maximum requests per window
+*   ``X-RateLimit-Remaining`` — requests remaining in current window
+*   ``Retry-After`` — seconds until reset (only on HTTP 429)
+
+Completion endpoints
+====================
+
+.. _api-complete:
+
+POST /cowriter/complete
+-----------------------
+
+Generate a completion from a prompt using the default or specified
+LLM configuration.
+
+**Request body:**
+
+.. code-block:: json
+
+    {
+        "prompt": "Write an introduction about TYPO3",
+        "configuration": "openai-default"
+    }
+
+**Response (200):**
+
+.. code-block:: json
+
+    {
+        "success": true,
+        "content": "TYPO3 is a powerful...",
+        "model": "gpt-5.2",
+        "finishReason": "stop",
+        "wasTruncated": false,
+        "wasFiltered": false,
+        "usage": {
+            "promptTokens": 50,
+            "completionTokens": 120,
+            "totalTokens": 170
+        }
+    }
+
+.. _api-stream:
+
+POST /cowriter/stream
+---------------------
+
+Stream a completion via Server-Sent Events (SSE). Same request format
+as ``/cowriter/complete``.
+
+Returns ``text/event-stream`` with JSON chunks:
+
+.. code-block:: text
+
+    data: {"content": "TYPO3 ", "done": false}
+    data: {"content": "is a ", "done": false}
+    data: {"content": "powerful...", "done": true, "model": "gpt-5.2"}
+
+.. _api-task-execute:
+
+POST /cowriter/task-execute
+---------------------------
+
+Execute a predefined task with context assembly.
+
+**Request body:**
+
+.. code-block:: json
+
+    {
+        "taskIdentifier": "improve-text",
+        "instruction": "Improve this text",
+        "context": "<p>Current editor content</p>",
+        "contextScope": "content_element",
+        "configuration": "openai-default",
+        "referencePages": [
+            {"pid": 42, "relation": "style guide"}
+        ]
+    }
+
+Translation
+===========
+
+.. _api-translate:
+
+POST /cowriter/translate
+------------------------
+
+Translate text to a target language.
+
+**Request body:**
+
+.. code-block:: json
+
+    {
+        "text": "Hello world",
+        "targetLanguage": "de",
+        "formality": "formal",
+        "domain": "technical",
+        "configuration": "claude-fast"
+    }
+
+``formality`` defaults to ``"default"``, ``domain`` defaults to
+``"general"``. ``configuration`` is optional.
+
+**Response (200):**
+
+.. code-block:: json
+
+    {
+        "success": true,
+        "translation": "Hallo Welt",
+        "sourceLanguage": "en",
+        "confidence": 0.95,
+        "usage": {
+            "promptTokens": 30,
+            "completionTokens": 10,
+            "totalTokens": 40
+        }
+    }
+
+Vision / Alt text
+=================
+
+.. _api-vision:
+
+POST /cowriter/vision
+---------------------
+
+Analyze an image and generate descriptive alt text.
+
+**Request body:**
+
+.. code-block:: json
+
+    {
+        "imageUrl": "https://example.com/photo.jpg",
+        "prompt": "Generate a concise, descriptive alt text for this image."
+    }
+
+The ``prompt`` defaults to a standard alt text generation prompt
+if omitted.
+
+**Response (200):**
+
+.. code-block:: json
+
+    {
+        "success": true,
+        "altText": "A red bicycle parked against a brick wall",
+        "model": "gpt-5.2",
+        "confidence": 0.92,
+        "usage": {
+            "promptTokens": 200,
+            "completionTokens": 15,
+            "totalTokens": 215
+        }
+    }
+
+Templates
+=========
+
+.. _api-templates:
+
+GET /cowriter/templates
+-----------------------
+
+List available prompt templates (tasks with ``category = 'content'``).
+
+**Response (200):**
+
+.. code-block:: json
+
+    {
+        "success": true,
+        "templates": [
+            {
+                "identifier": "improve-text",
+                "name": "Improve Text",
+                "description": "Enhance readability and quality",
+                "category": "content"
+            }
+        ]
+    }
+
+Tool calling
+============
+
+.. _api-tools:
+
+POST /cowriter/tools
+--------------------
+
+Execute an LLM request with tool calling capabilities.
+
+**Request body:**
+
+.. code-block:: json
+
+    {
+        "prompt": "Find all headings in the content",
+        "tools": ["query_content"]
+    }
+
+``tools`` is an optional array of tool names to enable. If omitted,
+all available tools are enabled.
+
+**Response (200):**
+
+.. code-block:: json
+
+    {
+        "success": true,
+        "content": "I found 3 headings...",
+        "toolCalls": [],
+        "finishReason": "stop",
+        "usage": {
+            "promptTokens": 100,
+            "completionTokens": 50,
+            "totalTokens": 150
+        }
+    }
+
+Configurations
+==============
+
+.. _api-configurations:
+
+GET /cowriter/configurations
+----------------------------
+
+List active LLM configurations available for selection.
+
+**Response (200):**
+
+.. code-block:: json
+
+    {
+        "success": true,
+        "configurations": [
+            {
+                "identifier": "openai-default",
+                "name": "OpenAI GPT-5.2",
+                "isDefault": true
+            }
+        ]
+    }
+
+Error responses
+===============
+
+All endpoints use standard HTTP status codes:
+
+*   **400** — Invalid JSON, missing required fields, or fields exceeding
+    maximum length (32 KB)
+*   **429** — Rate limit exceeded (includes ``Retry-After`` header)
+*   **500** — LLM service error
+
+.. code-block:: json
+
+    {
+        "success": false,
+        "error": "Missing or empty text parameter."
+    }

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -68,6 +68,29 @@ If you have your own RTE configuration file
         toolbar:
           items:
             - cowriter
+            - cowriterVision
+            - cowriterTranslate
+            - cowriterTemplates
+
+The four toolbar items are:
+
+``cowriter``
+    Main dialog — task-based content generation with preview
+
+``cowriterVision``
+    Generate image alt text via LLM vision analysis
+
+``cowriterTranslate``
+    Inline translation dropdown (10 languages)
+
+``cowriterTemplates``
+    Apply prompt template presets from the toolbar
+
+..  tip::
+
+    You can include only the toolbar items you need. For example, if you
+    only want the main dialog and translation, omit ``cowriterVision``
+    and ``cowriterTemplates``.
 
 Task configuration
 ==================

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -61,6 +61,10 @@ your content directly in the CKEditor rich text editor.
 
         How to use the AI Cowriter button in CKEditor.
 
+    ..  card:: :ref:`API Reference <api>`
+
+        AJAX endpoint documentation for developers.
+
 ----
 
 **Table of contents**
@@ -73,6 +77,7 @@ your content directly in the CKEditor rich text editor.
     Installation/Index
     Configuration/Index
     Usage/Index
+    Api/Index
 
 ..  toctree::
     :hidden:

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -31,8 +31,13 @@ Features
 
 *   **Task-based dialog**: Select from predefined tasks (Improve, Summarize,
     Extend, Fix Grammar, Translate) with result preview before inserting
-*   **CKEditor Integration**: Seamless toolbar button in TYPO3's rich text
-    editor
+*   **Inline translation**: Translate selected text directly from a toolbar
+    dropdown — supports 10 languages (German, English, French, Spanish,
+    Italian, Dutch, Portuguese, Polish, Japanese, Chinese)
+*   **Alt text generation**: Generate image alt text via LLM vision analysis
+*   **Prompt templates**: Apply prompt template presets from the toolbar
+*   **CKEditor Integration**: Four toolbar buttons for writing, translation,
+    vision, and templates
 *   **Multi-Provider Support**: Works with all LLM providers supported by
     nr-llm (OpenAI, Claude, Gemini, OpenRouter, Mistral, Groq)
 *   **Secure Backend Proxy**: API keys never exposed to frontend — all

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -89,6 +89,56 @@ with ``category = 'content'``. The following default tasks are provided:
     ``category = 'content'``. Use ``{{input}}`` in the prompt template
     as placeholder for the user's content.
 
+Inline translation
+==================
+
+The **Translate** dropdown in the CKEditor toolbar lets you translate
+selected text without opening the full dialog.
+
+1.  Select the text you want to translate
+2.  Click the Translate button (globe icon) in the toolbar
+3.  Choose the target language from the dropdown
+4.  The selected text is replaced with the translation
+
+Supported languages:
+
+*   German, English, French, Spanish, Italian
+*   Dutch, Portuguese, Polish, Japanese, Chinese
+
+..  note::
+
+    Inline translation requires text to be selected. If no text is
+    selected, nothing happens. For translating entire content elements,
+    use the task-based dialog instead.
+
+Alt text generation
+===================
+
+The **Vision** button (image icon) generates alt text for images using
+LLM vision analysis.
+
+1.  Place your cursor where you want the alt text inserted
+2.  Click the Vision button in the toolbar
+3.  Enter the image URL when prompted
+4.  The generated alt text is inserted at the cursor position
+
+..  tip::
+
+    This is useful for accessibility compliance — generate descriptive
+    alt text for images without leaving the editor.
+
+Prompt templates
+================
+
+The **Templates** dropdown lets you apply predefined prompt templates
+from the toolbar. Templates are loaded from the nr-llm extension's
+task configuration.
+
+1.  Click the Templates button (document icon) in the toolbar
+2.  Select a template from the dropdown
+3.  The Cowriter dialog opens with the template pre-selected
+4.  Review, optionally adjust instructions, and execute
+
 Model override
 ==============
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,18 @@ AI-powered content assistant for TYPO3 CKEditor - write better content with help
 ## Features
 
 - **Task-based dialog**: Select from predefined tasks (Improve, Summarize, Extend, Fix Grammar, Translate) with result preview before inserting
-- **CKEditor Integration**: Seamless toolbar button in TYPO3's rich text editor
+- **Vision / Alt Text**: Analyze images and generate descriptive alt text via the CKEditor toolbar
+- **Translation**: Translate selected text into 10+ languages directly from the toolbar dropdown
+- **Prompt Templates**: Load reusable prompt presets from the backend for consistent content generation
+- **Tool Calling**: Structured function calling that lets the LLM query TYPO3 content during conversations
+- **CKEditor Integration**: Four toolbar components — main dialog, vision, translation, and templates
 - **Multi-Provider Support**: Works with all LLM providers supported by nr-llm (OpenAI, Claude, Gemini, etc.)
-- **Secure Backend Proxy**: API keys never exposed to frontend - all requests proxied through TYPO3 backend
+- **Secure Backend Proxy**: API keys never exposed to frontend — all requests proxied through TYPO3 backend
 - **Context control**: Choose between selected text or full content element as context
 - **Ad-hoc instructions**: Add custom instructions per request (e.g., "Write in formal tone")
 - **Rate limiting**: 20 requests/minute per backend user
 - **Streaming**: Server-Sent Events for real-time completions
-- **XSS Protection**: All LLM output is HTML-escaped for defense in depth
+- **Content sanitization**: Frontend DOMParser-based sanitization with CKEditor's HTML processing pipeline
 
 ## Requirements
 
@@ -89,6 +93,9 @@ editor:
     toolbar:
       items:
         - cowriter
+        - cowriterVision
+        - cowriterTranslate
+        - cowriterTemplates
 ```
 
 ## Usage
@@ -120,9 +127,12 @@ Tasks are managed in the nr-llm extension (`tx_nrllm_task` table) with `category
 ## Architecture
 
 ```
-[CKEditor Button] → [CowriterDialog] → [AIService.js] → [TYPO3 AJAX]
-                          ↓                                    ↓
-                    [TYPO3 Modal]                        [AjaxController]
+CKEditor Toolbar
+  ├─ cowriter         → [CowriterDialog] → AIService.js → AjaxController
+  ├─ cowriterVision   → AIService.js     ──────────────→ VisionController
+  ├─ cowriterTranslate→ AIService.js     ──────────────→ TranslationController
+  ├─ cowriterTemplates→ AIService.js     ──────────────→ TemplateController
+  └─ (tool calling)   → AIService.js     ──────────────→ ToolController
                                                               ↓
                                                    [LlmServiceManagerInterface]
                                                               ↓
@@ -181,7 +191,7 @@ open var/coverage/unit/index.html
 
 - API keys stored in nr-llm with sodium encryption
 - All backend AJAX endpoints require TYPO3 authentication
-- LLM output HTML-escaped to prevent XSS
+- Frontend DOMParser-based content sanitization via CKEditor's HTML processing pipeline
 - TYPO3 backend route authentication with nonce-based URL tokens
 - Content Security Policy (CSP) compatible
 

--- a/Resources/Public/JavaScript/Ckeditor/AIService.js
+++ b/Resources/Public/JavaScript/Ckeditor/AIService.js
@@ -41,7 +41,7 @@
 export class AIService {
     /**
      * TYPO3 AJAX route URLs - populated from TYPO3.settings.ajaxUrls
-     * @type {{chat: string|null, complete: string|null, stream: string|null, tasks: string|null, taskExecute: string|null, context: string|null, vision: string|null, translate: string|null, templates: string|null}}
+     * @type {{chat: string|null, complete: string|null, stream: string|null, tasks: string|null, taskExecute: string|null, context: string|null, vision: string|null, translate: string|null, templates: string|null, tools: string|null}}
      * @private
      */
     _routes = {

--- a/Resources/Public/JavaScript/Ckeditor/AIService.js
+++ b/Resources/Public/JavaScript/Ckeditor/AIService.js
@@ -54,6 +54,7 @@ export class AIService {
         vision: null,
         translate: null,
         templates: null,
+        tools: null,
     };
 
     constructor() {
@@ -68,6 +69,7 @@ export class AIService {
             this._routes.vision = TYPO3.settings.ajaxUrls.tx_cowriter_vision || null;
             this._routes.translate = TYPO3.settings.ajaxUrls.tx_cowriter_translate || null;
             this._routes.templates = TYPO3.settings.ajaxUrls.tx_cowriter_templates || null;
+            this._routes.tools = TYPO3.settings.ajaxUrls.tx_cowriter_tools || null;
         }
     }
 
@@ -392,6 +394,32 @@ export class AIService {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ text, targetLanguage, ...options }),
+        });
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+            throw new Error(error.error || `HTTP ${response.status}`);
+        }
+
+        return response.json();
+    }
+
+    /**
+     * Execute a tool-calling request.
+     *
+     * @param {string} prompt - The prompt for the LLM
+     * @param {string[]} [tools=[]] - Tool names to enable
+     * @returns {Promise<{success: boolean, content: string, toolCalls: Array|null, finishReason: string}>}
+     */
+    async executeTools(prompt, tools = []) {
+        if (!this._routes.tools) {
+            throw new Error('Tools route not configured.');
+        }
+
+        const response = await fetch(this._routes.tools, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt, tools }),
         });
 
         if (!response.ok) {

--- a/Resources/Public/JavaScript/Ckeditor/AIService.js
+++ b/Resources/Public/JavaScript/Ckeditor/AIService.js
@@ -41,7 +41,7 @@
 export class AIService {
     /**
      * TYPO3 AJAX route URLs - populated from TYPO3.settings.ajaxUrls
-     * @type {{chat: string|null, complete: string|null, stream: string|null, tasks: string|null, taskExecute: string|null, context: string|null}}
+     * @type {{chat: string|null, complete: string|null, stream: string|null, tasks: string|null, taskExecute: string|null, context: string|null, vision: string|null, translate: string|null, templates: string|null}}
      * @private
      */
     _routes = {
@@ -51,6 +51,9 @@ export class AIService {
         tasks: null,
         taskExecute: null,
         context: null,
+        vision: null,
+        translate: null,
+        templates: null,
     };
 
     constructor() {
@@ -62,6 +65,9 @@ export class AIService {
             this._routes.tasks = TYPO3.settings.ajaxUrls.tx_cowriter_tasks || null;
             this._routes.taskExecute = TYPO3.settings.ajaxUrls.tx_cowriter_task_execute || null;
             this._routes.context = TYPO3.settings.ajaxUrls.tx_cowriter_context || null;
+            this._routes.vision = TYPO3.settings.ajaxUrls.tx_cowriter_vision || null;
+            this._routes.translate = TYPO3.settings.ajaxUrls.tx_cowriter_translate || null;
+            this._routes.templates = TYPO3.settings.ajaxUrls.tx_cowriter_templates || null;
         }
     }
 
@@ -329,6 +335,84 @@ export class AIService {
                 contextScope, recordContext, referencePages,
             }),
         });
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+            throw new Error(error.error || `HTTP ${response.status}`);
+        }
+
+        return response.json();
+    }
+
+    /**
+     * Analyze an image and generate alt text or description.
+     *
+     * @param {string} imageUrl - URL of the image to analyze
+     * @param {string} [prompt] - Custom analysis prompt
+     * @returns {Promise<{success: boolean, altText: string, model: string, confidence: number}>}
+     */
+    async analyzeImage(imageUrl, prompt) {
+        if (!this._routes.vision) {
+            throw new Error('Vision route not configured.');
+        }
+
+        const body = { imageUrl };
+        if (prompt) {
+            body.prompt = prompt;
+        }
+
+        const response = await fetch(this._routes.vision, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+            throw new Error(error.error || `HTTP ${response.status}`);
+        }
+
+        return response.json();
+    }
+
+    /**
+     * Translate text to a target language.
+     *
+     * @param {string} text - Text to translate
+     * @param {string} targetLanguage - ISO 639-1 language code
+     * @param {{formality?: string, domain?: string}} [options={}] - Translation options
+     * @returns {Promise<{success: boolean, translation: string, sourceLanguage: string, confidence: number}>}
+     */
+    async translate(text, targetLanguage, options = {}) {
+        if (!this._routes.translate) {
+            throw new Error('Translation route not configured.');
+        }
+
+        const response = await fetch(this._routes.translate, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text, targetLanguage, ...options }),
+        });
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+            throw new Error(error.error || `HTTP ${response.status}`);
+        }
+
+        return response.json();
+    }
+
+    /**
+     * Get available prompt templates.
+     *
+     * @returns {Promise<{success: boolean, templates: Array<{identifier: string, name: string, description: string, category: string}>}>}
+     */
+    async getTemplates() {
+        if (!this._routes.templates) {
+            throw new Error('Templates route not configured.');
+        }
+
+        const response = await fetch(this._routes.templates);
 
         if (!response.ok) {
             const error = await response.json().catch(() => ({ error: 'Unknown error' }));

--- a/Resources/Public/JavaScript/Ckeditor/UrlLoader.js
+++ b/Resources/Public/JavaScript/Ckeditor/UrlLoader.js
@@ -36,7 +36,7 @@ export function loadCowriterUrls() {
 
         // Merge only expected cowriter URL keys (defense-in-depth against prototype pollution).
         // Keep in sync with Configuration/Backend/AjaxRoutes.php
-        const allowedKeys = ['tx_cowriter_chat', 'tx_cowriter_complete', 'tx_cowriter_stream', 'tx_cowriter_configurations', 'tx_cowriter_tasks', 'tx_cowriter_task_execute', 'tx_cowriter_context', 'tx_cowriter_vision', 'tx_cowriter_translate', 'tx_cowriter_templates'];
+        const allowedKeys = ['tx_cowriter_chat', 'tx_cowriter_complete', 'tx_cowriter_stream', 'tx_cowriter_configurations', 'tx_cowriter_tasks', 'tx_cowriter_task_execute', 'tx_cowriter_context', 'tx_cowriter_vision', 'tx_cowriter_translate', 'tx_cowriter_templates', 'tx_cowriter_tools'];
         for (const key of allowedKeys) {
             if (Object.prototype.hasOwnProperty.call(urls, key) && typeof urls[key] === 'string') {
                 TYPO3.settings.ajaxUrls[key] = urls[key];

--- a/Resources/Public/JavaScript/Ckeditor/UrlLoader.js
+++ b/Resources/Public/JavaScript/Ckeditor/UrlLoader.js
@@ -36,7 +36,7 @@ export function loadCowriterUrls() {
 
         // Merge only expected cowriter URL keys (defense-in-depth against prototype pollution).
         // Keep in sync with Configuration/Backend/AjaxRoutes.php
-        const allowedKeys = ['tx_cowriter_chat', 'tx_cowriter_complete', 'tx_cowriter_stream', 'tx_cowriter_configurations', 'tx_cowriter_tasks', 'tx_cowriter_task_execute', 'tx_cowriter_context'];
+        const allowedKeys = ['tx_cowriter_chat', 'tx_cowriter_complete', 'tx_cowriter_stream', 'tx_cowriter_configurations', 'tx_cowriter_tasks', 'tx_cowriter_task_execute', 'tx_cowriter_context', 'tx_cowriter_vision', 'tx_cowriter_translate', 'tx_cowriter_templates'];
         for (const key of allowedKeys) {
             if (Object.prototype.hasOwnProperty.call(urls, key) && typeof urls[key] === 'string') {
                 TYPO3.settings.ajaxUrls[key] = urls[key];

--- a/Resources/Public/JavaScript/Ckeditor/cowriter.js
+++ b/Resources/Public/JavaScript/Ckeditor/cowriter.js
@@ -2,9 +2,26 @@
 // @ts-check
 
 import { Plugin } from "@ckeditor/ckeditor5-core";
-import { ButtonView } from "@ckeditor/ckeditor5-ui";
+import { ButtonView, createDropdown, addListToDropdown, Model, Collection } from "@ckeditor/ckeditor5-ui";
 import { AIService } from "@netresearch/t3_cowriter/AIService";
 import { CowriterDialog } from "@netresearch/t3_cowriter/CowriterDialog";
+
+/**
+ * Target languages for translation dropdown.
+ * @type {ReadonlyArray<{code: string, label: string}>}
+ */
+const TRANSLATION_LANGUAGES = [
+    { code: 'de', label: 'German' },
+    { code: 'en', label: 'English' },
+    { code: 'fr', label: 'French' },
+    { code: 'es', label: 'Spanish' },
+    { code: 'it', label: 'Italian' },
+    { code: 'nl', label: 'Dutch' },
+    { code: 'pt', label: 'Portuguese' },
+    { code: 'pl', label: 'Polish' },
+    { code: 'ja', label: 'Japanese' },
+    { code: 'zh', label: 'Chinese' },
+];
 
 /**
  * Cowriter CKEditor plugin.
@@ -164,6 +181,172 @@ export class Cowriter extends Plugin {
             });
 
             return button;
+        });
+
+        // Vision button — analyze image and generate alt text
+        editor.ui.componentFactory.add('cowriterVision', () => {
+            const button = new ButtonView();
+
+            button.set({
+                label: 'Cowriter - Generate alt text',
+                tooltip: true,
+                icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zm-5-7l-3 3.72L9 13l-3 4h12l-4-5z"/></svg>',
+            });
+
+            button.on('execute', async () => {
+                if (this._isProcessing) return;
+                this._isProcessing = true;
+
+                try {
+                    const imageUrl = prompt('Enter image URL for alt text generation:');
+                    if (!imageUrl) return;
+
+                    const result = await this._service.analyzeImage(imageUrl);
+                    if (result?.success && result.altText) {
+                        const viewFragment = editor.data.processor.toView(result.altText);
+                        const modelFragment = editor.data.toModel(viewFragment);
+                        editor.model.insertContent(modelFragment);
+                    }
+                } catch (error) {
+                    console.error('[Cowriter Vision]', error);
+                } finally {
+                    this._isProcessing = false;
+                }
+            });
+
+            return button;
+        });
+
+        // Translation dropdown — translate selected text
+        editor.ui.componentFactory.add('cowriterTranslate', (locale) => {
+            const dropdown = createDropdown(locale);
+            const items = new Collection();
+
+            for (const lang of TRANSLATION_LANGUAGES) {
+                const itemModel = new Model({
+                    label: lang.label,
+                    languageCode: lang.code,
+                    withText: true,
+                });
+                items.add({ type: 'button', model: itemModel });
+            }
+
+            addListToDropdown(dropdown, items);
+
+            dropdown.buttonView.set({
+                label: 'Cowriter - Translate',
+                tooltip: true,
+                withText: false,
+                icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M12.87 15.07l-2.54-2.51.03-.03A17.52 17.52 0 0014.07 6H17V4h-7V2H8v2H1v2h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"/></svg>',
+            });
+
+            dropdown.on('execute', async (event) => {
+                if (this._isProcessing) return;
+                this._isProcessing = true;
+
+                try {
+                    const langCode = event.source.languageCode;
+                    const selection = editor.model.document.selection;
+                    const selectedRange = selection.getFirstRange();
+
+                    let selectedText = '';
+                    if (selectedRange && !selectedRange.isCollapsed) {
+                        const content = model.getSelectedContent(selection);
+                        selectedText = editor.data.stringify(content);
+                    }
+
+                    if (!selectedText) {
+                        console.warn('[Cowriter Translate] No text selected for translation');
+                        return;
+                    }
+
+                    const result = await this._service.translate(selectedText, langCode);
+                    if (result?.success && result.translation) {
+                        const viewFragment = editor.data.processor.toView(result.translation);
+                        const modelFragment = editor.data.toModel(viewFragment);
+
+                        model.change((writer) => {
+                            writer.setSelection(selectedRange);
+                            editor.model.insertContent(modelFragment);
+                        });
+                    }
+                } catch (error) {
+                    console.error('[Cowriter Translate]', error);
+                } finally {
+                    this._isProcessing = false;
+                }
+            });
+
+            return dropdown;
+        });
+
+        // Templates dropdown — apply prompt template presets
+        editor.ui.componentFactory.add('cowriterTemplates', (locale) => {
+            const dropdown = createDropdown(locale);
+
+            dropdown.buttonView.set({
+                label: 'Cowriter - Templates',
+                tooltip: true,
+                withText: false,
+                icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true"><path d="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm-1 7V3.5L18.5 9H13zM6 20V4h5v5h5v11H6z"/></svg>',
+            });
+
+            // Load templates when dropdown opens
+            dropdown.on('change:isOpen', async () => {
+                if (!dropdown.isOpen) return;
+
+                try {
+                    const result = await this._service.getTemplates();
+                    if (!result?.success || !result.templates?.length) return;
+
+                    const items = new Collection();
+                    for (const tmpl of result.templates) {
+                        const itemModel = new Model({
+                            label: tmpl.name,
+                            templateIdentifier: tmpl.identifier,
+                            templateDescription: tmpl.description || '',
+                            withText: true,
+                        });
+                        items.add({ type: 'button', model: itemModel });
+                    }
+
+                    addListToDropdown(dropdown, items);
+                } catch (error) {
+                    console.error('[Cowriter Templates]', error);
+                }
+            });
+
+            dropdown.on('execute', async (event) => {
+                if (this._isProcessing) return;
+                this._isProcessing = true;
+
+                try {
+                    const selectedText = editor.getData();
+                    const caps = this._getEditorCapabilities();
+                    const recordContext = this._getRecordContext();
+
+                    // Open the cowriter dialog with the template pre-selected
+                    const dialog = new CowriterDialog(this._service);
+                    const dialogResult = await dialog.show(
+                        '', selectedText, caps, recordContext,
+                        { templateIdentifier: event.source.templateIdentifier },
+                    );
+
+                    if (dialogResult?.content) {
+                        const viewFragment = editor.data.processor.toView(dialogResult.content);
+                        const modelFragment = editor.data.toModel(viewFragment);
+                        editor.model.insertContent(modelFragment);
+                    }
+                } catch (error) {
+                    if (error?.message && error.message !== 'User cancelled') {
+                        console.error('[Cowriter Templates]', error);
+                    }
+                } finally {
+                    this._isProcessing = false;
+                }
+            });
+
+            return dropdown;
         });
     }
 }

--- a/Resources/Public/JavaScript/Ckeditor/cowriter.js
+++ b/Resources/Public/JavaScript/Ckeditor/cowriter.js
@@ -335,7 +335,9 @@ export class Cowriter extends Plugin {
                     if (dialogResult?.content) {
                         const viewFragment = editor.data.processor.toView(dialogResult.content);
                         const modelFragment = editor.data.toModel(viewFragment);
-                        editor.model.insertContent(modelFragment);
+                        model.change(() => {
+                            editor.model.insertContent(modelFragment);
+                        });
                     }
                 } catch (error) {
                     if (error?.message && error.message !== 'User cancelled') {

--- a/Resources/Public/JavaScript/Ckeditor/cowriter.js
+++ b/Resources/Public/JavaScript/Ckeditor/cowriter.js
@@ -203,9 +203,9 @@ export class Cowriter extends Plugin {
 
                     const result = await this._service.analyzeImage(imageUrl);
                     if (result?.success && result.altText) {
-                        const viewFragment = editor.data.processor.toView(result.altText);
-                        const modelFragment = editor.data.toModel(viewFragment);
-                        editor.model.insertContent(modelFragment);
+                        editor.model.change(writer => {
+                            writer.insertText(result.altText, editor.model.document.selection.getFirstPosition());
+                        });
                     }
                 } catch (error) {
                     console.error('[Cowriter Vision]', error);

--- a/Tests/E2E/AbstractE2ETestCase.php
+++ b/Tests/E2E/AbstractE2ETestCase.php
@@ -158,8 +158,10 @@ abstract class AbstractE2ETestCase extends TestCase
      */
     protected function createJsonRequest(array $body): ServerRequestInterface
     {
+        $json     = json_encode($body, JSON_THROW_ON_ERROR);
         $bodyStub = self::createStub(StreamInterface::class);
-        $bodyStub->method('getContents')->willReturn(json_encode($body, JSON_THROW_ON_ERROR));
+        $bodyStub->method('getContents')->willReturn($json);
+        $bodyStub->method('__toString')->willReturn($json);
 
         $request = self::createStub(ServerRequestInterface::class);
         $request->method('getBody')->willReturn($bodyStub);

--- a/Tests/E2E/NewFeatureWorkflowTest.php
+++ b/Tests/E2E/NewFeatureWorkflowTest.php
@@ -126,40 +126,47 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
     /**
      * Create a TemplateController with mocked dependencies.
      *
-     * @return array{controller: TemplateController, templateRepo: PromptTemplateRepository&MockObject}
+     * @return array{controller: TemplateController, templateRepo: PromptTemplateRepository&MockObject, rateLimiter: RateLimiterInterface&MockObject, context: Context&MockObject}
      */
     private function createTemplateStack(): array
     {
         $templateRepo = $this->createMock(PromptTemplateRepository::class);
+        $rateLimiter  = $this->createMock(RateLimiterInterface::class);
+        $context      = $this->createMock(Context::class);
+
+        // Default: allow all requests
+        $rateLimiter->method('checkLimit')->willReturn(
+            new RateLimitResult(allowed: true, limit: 20, remaining: 19, resetTime: time() + 60),
+        );
+
+        // Default: return user ID 1
+        $context->method('getPropertyFromAspect')->willReturn(1);
 
         $controller = new TemplateController(
             $templateRepo,
+            $rateLimiter,
+            $context,
             $this->logger,
         );
 
         return [
             'controller'   => $controller,
             'templateRepo' => $templateRepo,
+            'rateLimiter'  => $rateLimiter,
+            'context'      => $context,
         ];
     }
 
     // =========================================================================
-    // Helper: Create a parsed-body request
+    // Helper: Create a stub request (for controllers that don't read body)
     // =========================================================================
 
     /**
-     * Create a mock ServerRequest with parsed body data.
-     *
-     * The new controllers use $request->getParsedBody() directly.
-     *
-     * @param array<string, mixed> $body
+     * Create a stub ServerRequest (for TemplateController which doesn't read body).
      */
-    private function createParsedBodyRequest(array $body): ServerRequestInterface
+    private function createStubRequest(): ServerRequestInterface
     {
-        $request = self::createStub(ServerRequestInterface::class);
-        $request->method('getParsedBody')->willReturn($body);
-
-        return $request;
+        return self::createStub(ServerRequestInterface::class);
     }
 
     // =========================================================================
@@ -204,7 +211,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         $stack['visionService']->method('analyzeImageFull')->willReturn($response);
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'imageUrl' => 'https://example.com/dog.jpg',
             'prompt'   => 'Generate alt text for this image.',
         ]);
@@ -242,7 +249,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         );
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'imageUrl' => 'https://example.com/image.jpg',
         ]);
         $result = $controller->analyzeAction($request);
@@ -262,7 +269,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         $stack = $this->createVisionStack();
 
         // Act: empty body, no imageUrl
-        $request = $this->createParsedBodyRequest([]);
+        $request = $this->createJsonRequest([]);
         $result  = $stack['controller']->analyzeAction($request);
 
         // Assert
@@ -282,7 +289,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
             ->willThrowException(new RuntimeException('API connection timeout'));
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'imageUrl' => 'https://example.com/image.jpg',
         ]);
         $result = $stack['controller']->analyzeAction($request);
@@ -318,7 +325,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         $stack['translationService']->method('translate')->willReturn($result);
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'text'           => 'Hello World',
             'targetLanguage' => 'de',
         ]);
@@ -351,7 +358,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         $stack['translationService']->method('translate')->willReturn($result);
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'text'           => 'How are you?',
             'targetLanguage' => 'de',
             'formality'      => 'formal',
@@ -384,7 +391,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         );
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'text'           => 'Hello World',
             'targetLanguage' => 'de',
         ]);
@@ -405,7 +412,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         $stack = $this->createTranslationStack();
 
         // Act: empty text
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'text'           => '',
             'targetLanguage' => 'de',
         ]);
@@ -426,7 +433,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         $stack = $this->createTranslationStack();
 
         // Act: missing targetLanguage
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'text' => 'Hello World',
         ]);
         $response = $stack['controller']->translateAction($request);
@@ -448,7 +455,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
             ->willThrowException(new RuntimeException('Provider unavailable'));
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'text'           => 'Hello World',
             'targetLanguage' => 'de',
         ]);
@@ -479,7 +486,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         $stack['templateRepo']->method('findActive')->willReturn($queryResult);
 
         // Act
-        $request  = $this->createParsedBodyRequest([]);
+        $request  = $this->createStubRequest();
         $response = $stack['controller']->listAction($request);
 
         // Assert
@@ -507,7 +514,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         $stack['templateRepo']->method('findActive')->willReturn($queryResult);
 
         // Act
-        $request  = $this->createParsedBodyRequest([]);
+        $request  = $this->createStubRequest();
         $response = $stack['controller']->listAction($request);
 
         // Assert
@@ -527,7 +534,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
             ->willThrowException(new RuntimeException('Database connection lost'));
 
         // Act
-        $request  = $this->createParsedBodyRequest([]);
+        $request  = $this->createStubRequest();
         $response = $stack['controller']->listAction($request);
 
         // Assert
@@ -551,7 +558,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
         $stack['templateRepo']->method('findActive')->willReturn($queryResult);
 
         // Act
-        $request  = $this->createParsedBodyRequest([]);
+        $request  = $this->createStubRequest();
         $response = $stack['controller']->listAction($request);
 
         // Assert: only the 2 valid PromptTemplate instances appear

--- a/Tests/E2E/NewFeatureWorkflowTest.php
+++ b/Tests/E2E/NewFeatureWorkflowTest.php
@@ -1,0 +1,566 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\E2E;
+
+use Netresearch\NrLlm\Domain\Model\PromptTemplate;
+use Netresearch\NrLlm\Domain\Model\TranslationResult;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\Repository\PromptTemplateRepository;
+use Netresearch\NrLlm\Service\Feature\TranslationService;
+use Netresearch\NrLlm\Service\Feature\VisionService;
+use Netresearch\T3Cowriter\Controller\TemplateController;
+use Netresearch\T3Cowriter\Controller\TranslationController;
+use Netresearch\T3Cowriter\Controller\VisionController;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
+use Netresearch\T3Cowriter\Tests\Support\TestQueryResult;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+use stdClass;
+use TYPO3\CMS\Core\Context\Context;
+
+/**
+ * E2E tests for Vision, Translation, and Template controller workflows.
+ *
+ * Tests the full path from controller entry point through service layer
+ * and back, verifying correct data flow, error handling, and rate limiting.
+ */
+#[AllowMockObjectsWithoutExpectations]
+#[CoversClass(VisionController::class)]
+#[CoversClass(TranslationController::class)]
+#[CoversClass(TemplateController::class)]
+final class NewFeatureWorkflowTest extends AbstractE2ETestCase
+{
+    // =========================================================================
+    // Helper: Create Vision controller stack
+    // =========================================================================
+
+    /**
+     * Create a VisionController with mocked dependencies.
+     *
+     * @return array{controller: VisionController, visionService: VisionService&MockObject, rateLimiter: RateLimiterInterface&MockObject, context: Context&MockObject}
+     */
+    private function createVisionStack(): array
+    {
+        $visionService = $this->createMock(VisionService::class);
+        $rateLimiter   = $this->createMock(RateLimiterInterface::class);
+        $context       = $this->createMock(Context::class);
+
+        // Default: allow all requests
+        $rateLimiter->method('checkLimit')->willReturn(
+            new RateLimitResult(allowed: true, limit: 20, remaining: 19, resetTime: time() + 60),
+        );
+
+        // Default: return user ID 1
+        $context->method('getPropertyFromAspect')->willReturn(1);
+
+        $controller = new VisionController(
+            $visionService,
+            $rateLimiter,
+            $context,
+            $this->logger,
+        );
+
+        return [
+            'controller'    => $controller,
+            'visionService' => $visionService,
+            'rateLimiter'   => $rateLimiter,
+            'context'       => $context,
+        ];
+    }
+
+    // =========================================================================
+    // Helper: Create Translation controller stack
+    // =========================================================================
+
+    /**
+     * Create a TranslationController with mocked dependencies.
+     *
+     * @return array{controller: TranslationController, translationService: TranslationService&MockObject, rateLimiter: RateLimiterInterface&MockObject, context: Context&MockObject}
+     */
+    private function createTranslationStack(): array
+    {
+        $translationService = $this->createMock(TranslationService::class);
+        $rateLimiter        = $this->createMock(RateLimiterInterface::class);
+        $context            = $this->createMock(Context::class);
+
+        // Default: allow all requests
+        $rateLimiter->method('checkLimit')->willReturn(
+            new RateLimitResult(allowed: true, limit: 20, remaining: 19, resetTime: time() + 60),
+        );
+
+        // Default: return user ID 1
+        $context->method('getPropertyFromAspect')->willReturn(1);
+
+        $controller = new TranslationController(
+            $translationService,
+            $rateLimiter,
+            $context,
+            $this->logger,
+        );
+
+        return [
+            'controller'         => $controller,
+            'translationService' => $translationService,
+            'rateLimiter'        => $rateLimiter,
+            'context'            => $context,
+        ];
+    }
+
+    // =========================================================================
+    // Helper: Create Template controller stack
+    // =========================================================================
+
+    /**
+     * Create a TemplateController with mocked dependencies.
+     *
+     * @return array{controller: TemplateController, templateRepo: PromptTemplateRepository&MockObject}
+     */
+    private function createTemplateStack(): array
+    {
+        $templateRepo = $this->createMock(PromptTemplateRepository::class);
+
+        $controller = new TemplateController(
+            $templateRepo,
+            $this->logger,
+        );
+
+        return [
+            'controller'   => $controller,
+            'templateRepo' => $templateRepo,
+        ];
+    }
+
+    // =========================================================================
+    // Helper: Create a parsed-body request
+    // =========================================================================
+
+    /**
+     * Create a mock ServerRequest with parsed body data.
+     *
+     * The new controllers use $request->getParsedBody() directly.
+     *
+     * @param array<string, mixed> $body
+     */
+    private function createParsedBodyRequest(array $body): ServerRequestInterface
+    {
+        $request = self::createStub(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn($body);
+
+        return $request;
+    }
+
+    // =========================================================================
+    // Helper: Create a PromptTemplate stub
+    // =========================================================================
+
+    /**
+     * @return PromptTemplate&MockObject
+     */
+    private function createPromptTemplateStub(
+        string $identifier,
+        string $title,
+        ?string $description,
+        string $feature,
+    ): PromptTemplate&MockObject {
+        $template = $this->createMock(PromptTemplate::class);
+        $template->method('getIdentifier')->willReturn($identifier);
+        $template->method('getTitle')->willReturn($title);
+        $template->method('getDescription')->willReturn($description);
+        $template->method('getFeature')->willReturn($feature);
+
+        return $template;
+    }
+
+    // =========================================================================
+    // Vision Workflow Tests
+    // =========================================================================
+
+    #[Test]
+    public function visionWorkflowGeneratesAltText(): void
+    {
+        // Arrange
+        $stack    = $this->createVisionStack();
+        $usage    = new UsageStatistics(promptTokens: 100, completionTokens: 50, totalTokens: 150);
+        $response = new VisionResponse(
+            description: 'A golden retriever playing fetch in a sunny park.',
+            model: 'gpt-4o',
+            usage: $usage,
+            confidence: 0.95,
+        );
+
+        $stack['visionService']->method('analyzeImageFull')->willReturn($response);
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'imageUrl' => 'https://example.com/dog.jpg',
+            'prompt'   => 'Generate alt text for this image.',
+        ]);
+        $result = $stack['controller']->analyzeAction($request);
+
+        // Assert
+        self::assertSame(200, $result->getStatusCode());
+        $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertSame('A golden retriever playing fetch in a sunny park.', $data['altText']);
+        self::assertSame('gpt-4o', $data['model']);
+        self::assertSame(0.95, $data['confidence']);
+        self::assertSame(100, $data['usage']['promptTokens']);
+        self::assertSame(50, $data['usage']['completionTokens']);
+        self::assertSame(150, $data['usage']['totalTokens']);
+    }
+
+    #[Test]
+    public function visionWorkflowHandlesRateLimiting(): void
+    {
+        // Arrange: rate limiter denies request
+        $stack                = $this->createVisionStack();
+        $stack['rateLimiter'] = $this->createMock(RateLimiterInterface::class);
+        $stack['rateLimiter']->method('checkLimit')->willReturn(
+            new RateLimitResult(allowed: false, limit: 20, remaining: 0, resetTime: time() + 60),
+        );
+
+        // Rebuild controller with rate-limited limiter
+        $controller = new VisionController(
+            $stack['visionService'],
+            $stack['rateLimiter'],
+            $stack['context'],
+            $this->logger,
+        );
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'imageUrl' => 'https://example.com/image.jpg',
+        ]);
+        $result = $controller->analyzeAction($request);
+
+        // Assert
+        self::assertSame(429, $result->getStatusCode());
+        $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertFalse($data['success']);
+        self::assertStringContainsString('Rate limit', $data['error']);
+    }
+
+    #[Test]
+    public function visionWorkflowHandlesMissingImageUrl(): void
+    {
+        // Arrange
+        $stack = $this->createVisionStack();
+
+        // Act: empty body, no imageUrl
+        $request = $this->createParsedBodyRequest([]);
+        $result  = $stack['controller']->analyzeAction($request);
+
+        // Assert
+        self::assertSame(400, $result->getStatusCode());
+        $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertFalse($data['success']);
+        self::assertStringContainsString('imageUrl', $data['error']);
+    }
+
+    #[Test]
+    public function visionWorkflowHandlesServiceFailure(): void
+    {
+        // Arrange: VisionService throws
+        $stack = $this->createVisionStack();
+        $stack['visionService']->method('analyzeImageFull')
+            ->willThrowException(new RuntimeException('API connection timeout'));
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'imageUrl' => 'https://example.com/image.jpg',
+        ]);
+        $result = $stack['controller']->analyzeAction($request);
+
+        // Assert
+        self::assertSame(500, $result->getStatusCode());
+        $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertFalse($data['success']);
+        // Error should not expose internal details
+        self::assertStringNotContainsString('timeout', $data['error']);
+        self::assertStringContainsString('analysis failed', strtolower($data['error']));
+    }
+
+    // =========================================================================
+    // Translation Workflow Tests
+    // =========================================================================
+
+    #[Test]
+    public function translationWorkflowTranslatesText(): void
+    {
+        // Arrange
+        $stack  = $this->createTranslationStack();
+        $usage  = new UsageStatistics(promptTokens: 30, completionTokens: 25, totalTokens: 55);
+        $result = new TranslationResult(
+            translation: 'Hallo Welt',
+            sourceLanguage: 'en',
+            targetLanguage: 'de',
+            confidence: 0.98,
+            usage: $usage,
+        );
+
+        $stack['translationService']->method('translate')->willReturn($result);
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'text'           => 'Hello World',
+            'targetLanguage' => 'de',
+        ]);
+        $response = $stack['controller']->translateAction($request);
+
+        // Assert
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertSame('Hallo Welt', $data['translation']);
+        self::assertSame('en', $data['sourceLanguage']);
+        self::assertSame(0.98, $data['confidence']);
+    }
+
+    #[Test]
+    public function translationWorkflowWithFormalityOption(): void
+    {
+        // Arrange
+        $stack  = $this->createTranslationStack();
+        $usage  = new UsageStatistics(promptTokens: 40, completionTokens: 35, totalTokens: 75);
+        $result = new TranslationResult(
+            translation: 'Wie geht es Ihnen?',
+            sourceLanguage: 'en',
+            targetLanguage: 'de',
+            confidence: 0.96,
+            usage: $usage,
+        );
+
+        $stack['translationService']->method('translate')->willReturn($result);
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'text'           => 'How are you?',
+            'targetLanguage' => 'de',
+            'formality'      => 'formal',
+        ]);
+        $response = $stack['controller']->translateAction($request);
+
+        // Assert
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertSame('Wie geht es Ihnen?', $data['translation']);
+    }
+
+    #[Test]
+    public function translationWorkflowHandlesRateLimiting(): void
+    {
+        // Arrange: rate limiter denies request
+        $stack                = $this->createTranslationStack();
+        $stack['rateLimiter'] = $this->createMock(RateLimiterInterface::class);
+        $stack['rateLimiter']->method('checkLimit')->willReturn(
+            new RateLimitResult(allowed: false, limit: 20, remaining: 0, resetTime: time() + 60),
+        );
+
+        $controller = new TranslationController(
+            $stack['translationService'],
+            $stack['rateLimiter'],
+            $stack['context'],
+            $this->logger,
+        );
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'text'           => 'Hello World',
+            'targetLanguage' => 'de',
+        ]);
+        $response = $controller->translateAction($request);
+
+        // Assert
+        self::assertSame(429, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertFalse($data['success']);
+        self::assertStringContainsString('Rate limit', $data['error']);
+    }
+
+    #[Test]
+    public function translationWorkflowHandlesMissingText(): void
+    {
+        // Arrange
+        $stack = $this->createTranslationStack();
+
+        // Act: empty text
+        $request = $this->createParsedBodyRequest([
+            'text'           => '',
+            'targetLanguage' => 'de',
+        ]);
+        $response = $stack['controller']->translateAction($request);
+
+        // Assert
+        self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertFalse($data['success']);
+        self::assertStringContainsString('text', strtolower($data['error']));
+    }
+
+    #[Test]
+    public function translationWorkflowHandlesMissingTargetLanguage(): void
+    {
+        // Arrange
+        $stack = $this->createTranslationStack();
+
+        // Act: missing targetLanguage
+        $request = $this->createParsedBodyRequest([
+            'text' => 'Hello World',
+        ]);
+        $response = $stack['controller']->translateAction($request);
+
+        // Assert
+        self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertFalse($data['success']);
+        self::assertStringContainsString('targetlanguage', strtolower($data['error']));
+    }
+
+    #[Test]
+    public function translationWorkflowHandlesServiceFailure(): void
+    {
+        // Arrange: TranslationService throws
+        $stack = $this->createTranslationStack();
+        $stack['translationService']->method('translate')
+            ->willThrowException(new RuntimeException('Provider unavailable'));
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'text'           => 'Hello World',
+            'targetLanguage' => 'de',
+        ]);
+        $response = $stack['controller']->translateAction($request);
+
+        // Assert
+        self::assertSame(500, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertFalse($data['success']);
+        self::assertStringNotContainsString('unavailable', $data['error']);
+        self::assertStringContainsString('translation failed', strtolower($data['error']));
+    }
+
+    // =========================================================================
+    // Template Workflow Tests
+    // =========================================================================
+
+    #[Test]
+    public function templateWorkflowListsActiveTemplates(): void
+    {
+        // Arrange
+        $stack     = $this->createTemplateStack();
+        $template1 = $this->createPromptTemplateStub('improve-text', 'Improve Text', 'Improves text quality', 'writing');
+        $template2 = $this->createPromptTemplateStub('summarize', 'Summarize', 'Creates summaries', 'analysis');
+
+        $queryResult = new TestQueryResult([$template1, $template2]);
+        $stack['templateRepo']->method('findActive')->willReturn($queryResult);
+
+        // Act
+        $request  = $this->createParsedBodyRequest([]);
+        $response = $stack['controller']->listAction($request);
+
+        // Assert
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertCount(2, $data['templates']);
+
+        self::assertSame('improve-text', $data['templates'][0]['identifier']);
+        self::assertSame('Improve Text', $data['templates'][0]['name']);
+        self::assertSame('Improves text quality', $data['templates'][0]['description']);
+        self::assertSame('writing', $data['templates'][0]['category']);
+
+        self::assertSame('summarize', $data['templates'][1]['identifier']);
+        self::assertSame('Summarize', $data['templates'][1]['name']);
+    }
+
+    #[Test]
+    public function templateWorkflowHandlesEmptyTemplateList(): void
+    {
+        // Arrange
+        $stack       = $this->createTemplateStack();
+        $queryResult = new TestQueryResult([]);
+        $stack['templateRepo']->method('findActive')->willReturn($queryResult);
+
+        // Act
+        $request  = $this->createParsedBodyRequest([]);
+        $response = $stack['controller']->listAction($request);
+
+        // Assert
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertSame([], $data['templates']);
+    }
+
+    #[Test]
+    public function templateWorkflowHandlesRepositoryError(): void
+    {
+        // Arrange: repository throws
+        $stack = $this->createTemplateStack();
+        $stack['templateRepo']->method('findActive')
+            ->willThrowException(new RuntimeException('Database connection lost'));
+
+        // Act
+        $request  = $this->createParsedBodyRequest([]);
+        $response = $stack['controller']->listAction($request);
+
+        // Assert
+        self::assertSame(500, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertFalse($data['success']);
+        self::assertStringNotContainsString('Database', $data['error']);
+        self::assertStringContainsString('templates', strtolower($data['error']));
+    }
+
+    #[Test]
+    public function templateWorkflowSkipsInvalidObjects(): void
+    {
+        // Arrange: mixed objects — only PromptTemplate instances should appear
+        $stack         = $this->createTemplateStack();
+        $validTemplate = $this->createPromptTemplateStub('valid', 'Valid Template', 'A valid one', 'writing');
+        $invalidObject = new stdClass();
+
+        $queryResult = new TestQueryResult([$validTemplate, $invalidObject, $validTemplate]);
+        $stack['templateRepo']->method('findActive')->willReturn($queryResult);
+
+        // Act
+        $request  = $this->createParsedBodyRequest([]);
+        $response = $stack['controller']->listAction($request);
+
+        // Assert: only the 2 valid PromptTemplate instances appear
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertCount(2, $data['templates']);
+        self::assertSame('valid', $data['templates'][0]['identifier']);
+        self::assertSame('valid', $data['templates'][1]['identifier']);
+    }
+}

--- a/Tests/Integration/AbstractIntegrationTestCase.php
+++ b/Tests/Integration/AbstractIntegrationTestCase.php
@@ -37,8 +37,10 @@ abstract class AbstractIntegrationTestCase extends TestCase
      */
     protected function createJsonRequest(array $body): ServerRequestInterface
     {
+        $json     = json_encode($body, JSON_THROW_ON_ERROR);
         $bodyStub = self::createStub(StreamInterface::class);
-        $bodyStub->method('getContents')->willReturn(json_encode($body, JSON_THROW_ON_ERROR));
+        $bodyStub->method('getContents')->willReturn($json);
+        $bodyStub->method('__toString')->willReturn($json);
 
         $request = self::createStub(ServerRequestInterface::class);
         $request->method('getBody')->willReturn($bodyStub);

--- a/Tests/Integration/Controller/TemplateControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/TemplateControllerIntegrationTest.php
@@ -12,6 +12,8 @@ namespace Netresearch\T3Cowriter\Tests\Integration\Controller;
 use Netresearch\NrLlm\Domain\Model\PromptTemplate;
 use Netresearch\NrLlm\Domain\Repository\PromptTemplateRepository;
 use Netresearch\T3Cowriter\Controller\TemplateController;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
 use Netresearch\T3Cowriter\Tests\Integration\AbstractIntegrationTestCase;
 use Netresearch\T3Cowriter\Tests\Support\TestQueryResult;
 use Override;
@@ -22,6 +24,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\NullLogger;
 use stdClass;
+use TYPO3\CMS\Core\Context\Context;
 
 /**
  * Integration tests for TemplateController.
@@ -43,23 +46,28 @@ final class TemplateControllerIntegrationTest extends AbstractIntegrationTestCas
 
         $this->templateRepoMock = $this->createMock(PromptTemplateRepository::class);
 
+        $rateLimiter = $this->createStub(RateLimiterInterface::class);
+        $rateLimiter->method('checkLimit')->willReturn(
+            new RateLimitResult(allowed: true, limit: 20, remaining: 19, resetTime: time() + 60),
+        );
+
+        $context = $this->createStub(Context::class);
+        $context->method('getPropertyFromAspect')->willReturn(1);
+
         $this->subject = new TemplateController(
             $this->templateRepoMock,
+            $rateLimiter,
+            $context,
             new NullLogger(),
         );
     }
 
     /**
-     * Create a mock ServerRequest with parsed body data.
-     *
-     * @param array<string, mixed> $body
+     * Create a stub ServerRequest (TemplateController doesn't read body).
      */
-    private function createParsedBodyRequest(array $body = []): ServerRequestInterface
+    private function createStubRequest(): ServerRequestInterface
     {
-        $request = self::createStub(ServerRequestInterface::class);
-        $request->method('getParsedBody')->willReturn($body);
-
-        return $request;
+        return self::createStub(ServerRequestInterface::class);
     }
 
     /**
@@ -101,7 +109,7 @@ final class TemplateControllerIntegrationTest extends AbstractIntegrationTestCas
         $this->templateRepoMock->method('findActive')->willReturn($queryResult);
 
         // Act
-        $request  = $this->createParsedBodyRequest();
+        $request  = $this->createStubRequest();
         $response = $this->subject->listAction($request);
 
         // Assert
@@ -131,7 +139,7 @@ final class TemplateControllerIntegrationTest extends AbstractIntegrationTestCas
         $this->templateRepoMock->method('findActive')->willReturn($queryResult);
 
         // Act
-        $request  = $this->createParsedBodyRequest();
+        $request  = $this->createStubRequest();
         $response = $this->subject->listAction($request);
 
         // Assert
@@ -159,7 +167,7 @@ final class TemplateControllerIntegrationTest extends AbstractIntegrationTestCas
         $this->templateRepoMock->method('findActive')->willReturn($queryResult);
 
         // Act
-        $request  = $this->createParsedBodyRequest();
+        $request  = $this->createStubRequest();
         $response = $this->subject->listAction($request);
 
         // Assert: only the PromptTemplate instance is in the result

--- a/Tests/Integration/Controller/TemplateControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/TemplateControllerIntegrationTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Integration\Controller;
+
+use Netresearch\NrLlm\Domain\Model\PromptTemplate;
+use Netresearch\NrLlm\Domain\Repository\PromptTemplateRepository;
+use Netresearch\T3Cowriter\Controller\TemplateController;
+use Netresearch\T3Cowriter\Tests\Integration\AbstractIntegrationTestCase;
+use Netresearch\T3Cowriter\Tests\Support\TestQueryResult;
+use Override;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\NullLogger;
+use stdClass;
+
+/**
+ * Integration tests for TemplateController.
+ *
+ * Tests complete request/response flows through the controller
+ * with mocked PromptTemplateRepository responses.
+ */
+#[AllowMockObjectsWithoutExpectations]
+#[CoversClass(TemplateController::class)]
+final class TemplateControllerIntegrationTest extends AbstractIntegrationTestCase
+{
+    private TemplateController $subject;
+    private PromptTemplateRepository&MockObject $templateRepoMock;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->templateRepoMock = $this->createMock(PromptTemplateRepository::class);
+
+        $this->subject = new TemplateController(
+            $this->templateRepoMock,
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * Create a mock ServerRequest with parsed body data.
+     *
+     * @param array<string, mixed> $body
+     */
+    private function createParsedBodyRequest(array $body = []): ServerRequestInterface
+    {
+        $request = self::createStub(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn($body);
+
+        return $request;
+    }
+
+    /**
+     * Create a PromptTemplate stub with common field values.
+     *
+     * @return PromptTemplate&MockObject
+     */
+    private function createPromptTemplateStub(
+        string $identifier,
+        string $title,
+        ?string $description,
+        string $feature,
+    ): PromptTemplate&MockObject {
+        $template = $this->createMock(PromptTemplate::class);
+        $template->method('getIdentifier')->willReturn($identifier);
+        $template->method('getTitle')->willReturn($title);
+        $template->method('getDescription')->willReturn($description);
+        $template->method('getFeature')->willReturn($feature);
+
+        return $template;
+    }
+
+    // =========================================================================
+    // List Flow Tests
+    // =========================================================================
+
+    #[Test]
+    public function listFlowReturnsFormattedTemplates(): void
+    {
+        // Arrange
+        $template = $this->createPromptTemplateStub(
+            'improve-text',
+            'Improve Text',
+            'Enhances text quality and readability.',
+            'writing',
+        );
+
+        $queryResult = new TestQueryResult([$template]);
+        $this->templateRepoMock->method('findActive')->willReturn($queryResult);
+
+        // Act
+        $request  = $this->createParsedBodyRequest();
+        $response = $this->subject->listAction($request);
+
+        // Assert
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertCount(1, $data['templates']);
+
+        // Verify field mapping: title -> name, feature -> category
+        $entry = $data['templates'][0];
+        self::assertSame('improve-text', $entry['identifier']);
+        self::assertSame('Improve Text', $entry['name']);
+        self::assertSame('Enhances text quality and readability.', $entry['description']);
+        self::assertSame('writing', $entry['category']);
+    }
+
+    #[Test]
+    public function listFlowHandlesMultipleTemplates(): void
+    {
+        // Arrange
+        $template1 = $this->createPromptTemplateStub('improve-text', 'Improve Text', 'Improves quality', 'writing');
+        $template2 = $this->createPromptTemplateStub('summarize', 'Summarize', null, 'analysis');
+        $template3 = $this->createPromptTemplateStub('translate-formal', 'Formal Translation', 'Formal tone', 'translation');
+
+        $queryResult = new TestQueryResult([$template1, $template2, $template3]);
+        $this->templateRepoMock->method('findActive')->willReturn($queryResult);
+
+        // Act
+        $request  = $this->createParsedBodyRequest();
+        $response = $this->subject->listAction($request);
+
+        // Assert
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertCount(3, $data['templates']);
+
+        self::assertSame('improve-text', $data['templates'][0]['identifier']);
+        self::assertSame('summarize', $data['templates'][1]['identifier']);
+        self::assertSame('translate-formal', $data['templates'][2]['identifier']);
+
+        // Null description becomes empty string
+        self::assertSame('', $data['templates'][1]['description']);
+    }
+
+    #[Test]
+    public function listFlowFiltersNonTemplateObjects(): void
+    {
+        // Arrange: QueryResult contains a mix of PromptTemplate and stdClass
+        $validTemplate = $this->createPromptTemplateStub('valid', 'Valid Template', 'A valid one', 'writing');
+        $invalidObject = new stdClass();
+
+        $queryResult = new TestQueryResult([$validTemplate, $invalidObject]);
+        $this->templateRepoMock->method('findActive')->willReturn($queryResult);
+
+        // Act
+        $request  = $this->createParsedBodyRequest();
+        $response = $this->subject->listAction($request);
+
+        // Assert: only the PromptTemplate instance is in the result
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertCount(1, $data['templates']);
+        self::assertSame('valid', $data['templates'][0]['identifier']);
+    }
+}

--- a/Tests/Integration/Controller/TranslationControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/TranslationControllerIntegrationTest.php
@@ -21,7 +21,6 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Context\Context;
 
@@ -66,19 +65,6 @@ final class TranslationControllerIntegrationTest extends AbstractIntegrationTest
     }
 
     /**
-     * Create a mock ServerRequest with parsed body data.
-     *
-     * @param array<string, mixed> $body
-     */
-    private function createParsedBodyRequest(array $body): ServerRequestInterface
-    {
-        $request = self::createStub(ServerRequestInterface::class);
-        $request->method('getParsedBody')->willReturn($body);
-
-        return $request;
-    }
-
-    /**
      * Create a TranslationResult with realistic data.
      */
     private function createTranslationResult(
@@ -115,7 +101,7 @@ final class TranslationControllerIntegrationTest extends AbstractIntegrationTest
         $this->translationServiceMock->method('translate')->willReturn($result);
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'text'           => 'Welcome to our website.',
             'targetLanguage' => 'de',
         ]);
@@ -147,7 +133,7 @@ final class TranslationControllerIntegrationTest extends AbstractIntegrationTest
             ->willReturn($result);
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'text'           => 'Dear Ladies and Gentlemen, welcome.',
             'targetLanguage' => 'de',
             'formality'      => 'formal',
@@ -172,7 +158,7 @@ final class TranslationControllerIntegrationTest extends AbstractIntegrationTest
         $this->translationServiceMock->method('translate')->willReturn($result);
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'text'           => 'An image shows bold text and special characters',
             'targetLanguage' => 'de',
         ]);
@@ -199,7 +185,7 @@ final class TranslationControllerIntegrationTest extends AbstractIntegrationTest
         $this->translationServiceMock->method('translate')->willReturn($result);
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'text'           => 'Test',
             'targetLanguage' => 'de',
         ]);

--- a/Tests/Integration/Controller/TranslationControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/TranslationControllerIntegrationTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Integration\Controller;
+
+use Netresearch\NrLlm\Domain\Model\TranslationResult;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Feature\TranslationService;
+use Netresearch\T3Cowriter\Controller\TranslationController;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
+use Netresearch\T3Cowriter\Tests\Integration\AbstractIntegrationTestCase;
+use Override;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Context\Context;
+
+/**
+ * Integration tests for TranslationController.
+ *
+ * Tests complete request/response flows through the controller
+ * with mocked TranslationService responses.
+ */
+#[AllowMockObjectsWithoutExpectations]
+#[CoversClass(TranslationController::class)]
+final class TranslationControllerIntegrationTest extends AbstractIntegrationTestCase
+{
+    private TranslationController $subject;
+    private TranslationService&MockObject $translationServiceMock;
+    private RateLimiterInterface&MockObject $rateLimiterMock;
+    private Context&MockObject $contextMock;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->translationServiceMock = $this->createMock(TranslationService::class);
+        $this->rateLimiterMock        = $this->createMock(RateLimiterInterface::class);
+        $this->contextMock            = $this->createMock(Context::class);
+
+        // Default: rate limiter allows requests
+        $this->rateLimiterMock->method('checkLimit')->willReturn(
+            new RateLimitResult(allowed: true, limit: 20, remaining: 19, resetTime: time() + 60),
+        );
+
+        // Default: context returns user ID
+        $this->contextMock->method('getPropertyFromAspect')->willReturn(1);
+
+        $this->subject = new TranslationController(
+            $this->translationServiceMock,
+            $this->rateLimiterMock,
+            $this->contextMock,
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * Create a mock ServerRequest with parsed body data.
+     *
+     * @param array<string, mixed> $body
+     */
+    private function createParsedBodyRequest(array $body): ServerRequestInterface
+    {
+        $request = self::createStub(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn($body);
+
+        return $request;
+    }
+
+    /**
+     * Create a TranslationResult with realistic data.
+     */
+    private function createTranslationResult(
+        string $translation = 'Translated text.',
+        string $sourceLanguage = 'en',
+        string $targetLanguage = 'de',
+        float $confidence = 0.95,
+        int $promptTokens = 30,
+        int $completionTokens = 25,
+    ): TranslationResult {
+        return new TranslationResult(
+            translation: $translation,
+            sourceLanguage: $sourceLanguage,
+            targetLanguage: $targetLanguage,
+            confidence: $confidence,
+            usage: UsageStatistics::fromTokens($promptTokens, $completionTokens),
+        );
+    }
+
+    // =========================================================================
+    // Complete Flow Tests
+    // =========================================================================
+
+    #[Test]
+    public function translateFlowWithDefaultOptions(): void
+    {
+        // Arrange
+        $result = $this->createTranslationResult(
+            'Willkommen auf unserer Webseite.',
+            'en',
+            'de',
+            0.97,
+        );
+        $this->translationServiceMock->method('translate')->willReturn($result);
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'text'           => 'Welcome to our website.',
+            'targetLanguage' => 'de',
+        ]);
+        $response = $this->subject->translateAction($request);
+
+        // Assert
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertSame('Willkommen auf unserer Webseite.', $data['translation']);
+        self::assertSame('en', $data['sourceLanguage']);
+        self::assertSame(0.97, $data['confidence']);
+        self::assertArrayHasKey('usage', $data);
+    }
+
+    #[Test]
+    public function translateFlowWithFormalityAndDomain(): void
+    {
+        // Arrange: verify options are passed through
+        $result = $this->createTranslationResult(
+            'Sehr geehrte Damen und Herren, willkommen.',
+            'en',
+            'de',
+            0.94,
+        );
+        $this->translationServiceMock
+            ->method('translate')
+            ->willReturn($result);
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'text'           => 'Dear Ladies and Gentlemen, welcome.',
+            'targetLanguage' => 'de',
+            'formality'      => 'formal',
+            'domain'         => 'marketing',
+        ]);
+        $response = $this->subject->translateAction($request);
+
+        // Assert
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertSame('Sehr geehrte Damen und Herren, willkommen.', $data['translation']);
+    }
+
+    #[Test]
+    public function translateFlowReturnsRawContentInResponse(): void
+    {
+        // Arrange: TranslationService returns content with HTML-like characters
+        $translatedText = 'Ein Bild zeigt <strong>fetten Text</strong> & Sonderzeichen';
+        $result         = $this->createTranslationResult($translatedText);
+        $this->translationServiceMock->method('translate')->willReturn($result);
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'text'           => 'An image shows bold text and special characters',
+            'targetLanguage' => 'de',
+        ]);
+        $response = $this->subject->translateAction($request);
+
+        // Assert: Raw content returned — JSON encoding handles transport safety
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertSame($translatedText, $data['translation']);
+    }
+
+    #[Test]
+    public function translateFlowIncludesUsageStatistics(): void
+    {
+        // Arrange
+        $result = $this->createTranslationResult(
+            'Test',
+            'en',
+            'de',
+            0.9,
+            promptTokens: 45,
+            completionTokens: 38,
+        );
+        $this->translationServiceMock->method('translate')->willReturn($result);
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'text'           => 'Test',
+            'targetLanguage' => 'de',
+        ]);
+        $response = $this->subject->translateAction($request);
+
+        // Assert
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('usage', $data);
+        self::assertSame(45, $data['usage']['promptTokens']);
+        self::assertSame(38, $data['usage']['completionTokens']);
+        self::assertSame(83, $data['usage']['totalTokens']);
+    }
+}

--- a/Tests/Integration/Controller/VisionControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/VisionControllerIntegrationTest.php
@@ -21,7 +21,6 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Context\Context;
 
@@ -66,19 +65,6 @@ final class VisionControllerIntegrationTest extends AbstractIntegrationTestCase
     }
 
     /**
-     * Create a mock ServerRequest with parsed body data.
-     *
-     * @param array<string, mixed> $body
-     */
-    private function createParsedBodyRequest(array $body): ServerRequestInterface
-    {
-        $request = self::createStub(ServerRequestInterface::class);
-        $request->method('getParsedBody')->willReturn($body);
-
-        return $request;
-    }
-
-    /**
      * Create a VisionResponse with realistic data.
      */
     private function createVisionResponse(
@@ -110,7 +96,7 @@ final class VisionControllerIntegrationTest extends AbstractIntegrationTestCase
         $this->visionServiceMock->method('analyzeImageFull')->willReturn($response);
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'imageUrl' => 'https://example.com/cat-desk.jpg',
         ]);
         $result = $this->subject->analyzeAction($request);
@@ -135,7 +121,7 @@ final class VisionControllerIntegrationTest extends AbstractIntegrationTestCase
         $this->visionServiceMock->method('analyzeImageFull')->willReturn($response);
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'imageUrl' => 'https://example.com/image.jpg',
         ]);
         $result = $this->subject->analyzeAction($request);
@@ -159,7 +145,7 @@ final class VisionControllerIntegrationTest extends AbstractIntegrationTestCase
         $this->visionServiceMock->method('analyzeImageFull')->willReturn($response);
 
         // Act
-        $request = $this->createParsedBodyRequest([
+        $request = $this->createJsonRequest([
             'imageUrl' => 'https://example.com/image.jpg',
         ]);
         $result = $this->subject->analyzeAction($request);

--- a/Tests/Integration/Controller/VisionControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/VisionControllerIntegrationTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Integration\Controller;
+
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Service\Feature\VisionService;
+use Netresearch\T3Cowriter\Controller\VisionController;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
+use Netresearch\T3Cowriter\Tests\Integration\AbstractIntegrationTestCase;
+use Override;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Context\Context;
+
+/**
+ * Integration tests for VisionController.
+ *
+ * Tests complete request/response flows through the controller
+ * with mocked VisionService responses.
+ */
+#[AllowMockObjectsWithoutExpectations]
+#[CoversClass(VisionController::class)]
+final class VisionControllerIntegrationTest extends AbstractIntegrationTestCase
+{
+    private VisionController $subject;
+    private VisionService&MockObject $visionServiceMock;
+    private RateLimiterInterface&MockObject $rateLimiterMock;
+    private Context&MockObject $contextMock;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->visionServiceMock = $this->createMock(VisionService::class);
+        $this->rateLimiterMock   = $this->createMock(RateLimiterInterface::class);
+        $this->contextMock       = $this->createMock(Context::class);
+
+        // Default: rate limiter allows requests
+        $this->rateLimiterMock->method('checkLimit')->willReturn(
+            new RateLimitResult(allowed: true, limit: 20, remaining: 19, resetTime: time() + 60),
+        );
+
+        // Default: context returns user ID
+        $this->contextMock->method('getPropertyFromAspect')->willReturn(1);
+
+        $this->subject = new VisionController(
+            $this->visionServiceMock,
+            $this->rateLimiterMock,
+            $this->contextMock,
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * Create a mock ServerRequest with parsed body data.
+     *
+     * @param array<string, mixed> $body
+     */
+    private function createParsedBodyRequest(array $body): ServerRequestInterface
+    {
+        $request = self::createStub(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn($body);
+
+        return $request;
+    }
+
+    /**
+     * Create a VisionResponse with realistic data.
+     */
+    private function createVisionResponse(
+        string $description = 'A descriptive alt text for the image.',
+        string $model = 'gpt-4o',
+        int $promptTokens = 100,
+        int $completionTokens = 50,
+        float $confidence = 0.92,
+    ): VisionResponse {
+        return new VisionResponse(
+            description: $description,
+            model: $model,
+            usage: UsageStatistics::fromTokens($promptTokens, $completionTokens),
+            confidence: $confidence,
+        );
+    }
+
+    // =========================================================================
+    // Complete Flow Tests
+    // =========================================================================
+
+    #[Test]
+    public function analyzeFlowWithDefaultOptions(): void
+    {
+        // Arrange: Setup VisionService response
+        $response = $this->createVisionResponse(
+            'A white cat sitting on a wooden desk next to a laptop.',
+        );
+        $this->visionServiceMock->method('analyzeImageFull')->willReturn($response);
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'imageUrl' => 'https://example.com/cat-desk.jpg',
+        ]);
+        $result = $this->subject->analyzeAction($request);
+
+        // Assert
+        self::assertSame(200, $result->getStatusCode());
+        $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['success']);
+        self::assertSame('A white cat sitting on a wooden desk next to a laptop.', $data['altText']);
+        self::assertSame('gpt-4o', $data['model']);
+        self::assertArrayHasKey('confidence', $data);
+        self::assertArrayHasKey('usage', $data);
+    }
+
+    #[Test]
+    public function analyzeFlowReturnsRawContentInResponse(): void
+    {
+        // Arrange: VisionService returns content with HTML-like characters
+        $description = 'An image showing <strong>bold text</strong> & special "characters"';
+        $response    = $this->createVisionResponse($description);
+        $this->visionServiceMock->method('analyzeImageFull')->willReturn($response);
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'imageUrl' => 'https://example.com/image.jpg',
+        ]);
+        $result = $this->subject->analyzeAction($request);
+
+        // Assert: Raw content returned — JSON encoding is the transport safety
+        $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertSame($description, $data['altText']);
+    }
+
+    #[Test]
+    public function analyzeFlowIncludesUsageStatistics(): void
+    {
+        // Arrange
+        $response = $this->createVisionResponse(
+            'Test description',
+            'gpt-4o',
+            promptTokens: 200,
+            completionTokens: 80,
+        );
+        $this->visionServiceMock->method('analyzeImageFull')->willReturn($response);
+
+        // Act
+        $request = $this->createParsedBodyRequest([
+            'imageUrl' => 'https://example.com/image.jpg',
+        ]);
+        $result = $this->subject->analyzeAction($request);
+
+        // Assert
+        $data = json_decode((string) $result->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('usage', $data);
+        self::assertSame(200, $data['usage']['promptTokens']);
+        self::assertSame(80, $data['usage']['completionTokens']);
+        self::assertSame(280, $data['usage']['totalTokens']);
+    }
+}

--- a/Tests/JavaScript/AIService.test.js
+++ b/Tests/JavaScript/AIService.test.js
@@ -845,6 +845,232 @@ describe('AIService', () => {
         });
     });
 
+    describe('analyzeImage', () => {
+        it('should throw when vision route is not configured', async () => {
+            const service = new AIService();
+            expect(service._routes.vision).toBeNull();
+            await expect(service.analyzeImage('https://example.com/image.jpg')).rejects.toThrow(
+                'Vision route not configured.'
+            );
+        });
+
+        it('should send POST with imageUrl and optional prompt', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_vision = '/typo3/ajax/tx_cowriter_vision';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            const mockResponse = {
+                success: true,
+                altText: 'A cat sitting on a mat',
+                model: 'gpt-4-vision',
+                confidence: 0.95,
+            };
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve(mockResponse),
+            });
+
+            const service = new ServiceClass();
+            const result = await service.analyzeImage('https://example.com/image.jpg');
+
+            expect(globalThis.fetch).toHaveBeenCalledWith('/typo3/ajax/tx_cowriter_vision', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ imageUrl: 'https://example.com/image.jpg' }),
+            });
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should handle custom prompt', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_vision = '/typo3/ajax/tx_cowriter_vision';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({ success: true, altText: 'Description' }),
+            });
+
+            const service = new ServiceClass();
+            await service.analyzeImage('https://example.com/image.jpg', 'Describe in detail');
+
+            const body = JSON.parse(globalThis.fetch.mock.calls[0][1].body);
+            expect(body.imageUrl).toBe('https://example.com/image.jpg');
+            expect(body.prompt).toBe('Describe in detail');
+        });
+
+        it('should throw on non-ok response', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_vision = '/typo3/ajax/tx_cowriter_vision';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 500,
+                json: () => Promise.resolve({ error: 'Vision processing failed' }),
+            });
+
+            const service = new ServiceClass();
+            await expect(service.analyzeImage('https://example.com/image.jpg')).rejects.toThrow(
+                'Vision processing failed'
+            );
+        });
+
+        it('should handle JSON parse error in error response', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_vision = '/typo3/ajax/tx_cowriter_vision';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 500,
+                json: () => Promise.reject(new Error('Parse error')),
+            });
+
+            const service = new ServiceClass();
+            await expect(service.analyzeImage('https://example.com/image.jpg')).rejects.toThrow(
+                'Unknown error'
+            );
+        });
+    });
+
+    describe('translate', () => {
+        it('should throw when translate route is not configured', async () => {
+            const service = new AIService();
+            expect(service._routes.translate).toBeNull();
+            await expect(service.translate('Hello', 'de')).rejects.toThrow(
+                'Translation route not configured.'
+            );
+        });
+
+        it('should send POST with text, targetLanguage, and optional options', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_translate = '/typo3/ajax/tx_cowriter_translate';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            const mockResponse = {
+                success: true,
+                translation: 'Hallo',
+                sourceLanguage: 'en',
+                confidence: 0.98,
+            };
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve(mockResponse),
+            });
+
+            const service = new ServiceClass();
+            const result = await service.translate('Hello', 'de');
+
+            expect(globalThis.fetch).toHaveBeenCalledWith('/typo3/ajax/tx_cowriter_translate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ text: 'Hello', targetLanguage: 'de' }),
+            });
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should merge options into request body', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_translate = '/typo3/ajax/tx_cowriter_translate';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({ success: true, translation: 'Hallo' }),
+            });
+
+            const service = new ServiceClass();
+            await service.translate('Hello', 'de', { formality: 'formal', domain: 'medical' });
+
+            const body = JSON.parse(globalThis.fetch.mock.calls[0][1].body);
+            expect(body.text).toBe('Hello');
+            expect(body.targetLanguage).toBe('de');
+            expect(body.formality).toBe('formal');
+            expect(body.domain).toBe('medical');
+        });
+
+        it('should throw on non-ok response', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_translate = '/typo3/ajax/tx_cowriter_translate';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 400,
+                json: () => Promise.resolve({ error: 'Unsupported language' }),
+            });
+
+            const service = new ServiceClass();
+            await expect(service.translate('Hello', 'xx')).rejects.toThrow(
+                'Unsupported language'
+            );
+        });
+    });
+
+    describe('getTemplates', () => {
+        it('should throw when templates route is not configured', async () => {
+            const service = new AIService();
+            expect(service._routes.templates).toBeNull();
+            await expect(service.getTemplates()).rejects.toThrow(
+                'Templates route not configured.'
+            );
+        });
+
+        it('should fetch templates via GET', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_templates = '/typo3/ajax/tx_cowriter_templates';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            const mockResponse = {
+                success: true,
+                templates: [
+                    { identifier: 'blog-post', name: 'Blog Post', description: 'Write a blog post', category: 'content' },
+                    { identifier: 'product-desc', name: 'Product Description', description: 'Write a product description', category: 'commerce' },
+                ],
+            };
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve(mockResponse),
+            });
+
+            const service = new ServiceClass();
+            const result = await service.getTemplates();
+
+            expect(globalThis.fetch).toHaveBeenCalledWith('/typo3/ajax/tx_cowriter_templates');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should throw on non-ok response', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_templates = '/typo3/ajax/tx_cowriter_templates';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 500,
+                json: () => Promise.resolve({ error: 'Failed to load templates' }),
+            });
+
+            const service = new ServiceClass();
+            await expect(service.getTemplates()).rejects.toThrow(
+                'Failed to load templates'
+            );
+        });
+    });
+
     describe('exports', () => {
         it('should not export legacy APIType or AIServiceOptions', async () => {
             const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');

--- a/Tests/JavaScript/AIService.test.js
+++ b/Tests/JavaScript/AIService.test.js
@@ -1071,6 +1071,100 @@ describe('AIService', () => {
         });
     });
 
+    describe('executeTools', () => {
+        it('should throw when tools route is not configured', async () => {
+            const service = new AIService();
+            await expect(service.executeTools('Query content')).rejects.toThrow(
+                'Tools route not configured.'
+            );
+        });
+
+        it('should send POST request with prompt and tools', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_tools = '/typo3/ajax/tx_cowriter_tools';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            const mockResponse = {
+                success: true,
+                content: 'Found 5 content elements',
+                toolCalls: [{ name: 'contentQuery', args: { page: 1 } }],
+                finishReason: 'stop',
+            };
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve(mockResponse),
+            });
+
+            const service = new ServiceClass();
+            const result = await service.executeTools('Find content', ['contentQuery']);
+
+            expect(fetch).toHaveBeenCalledWith('/typo3/ajax/tx_cowriter_tools', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ prompt: 'Find content', tools: ['contentQuery'] }),
+            });
+            expect(result.success).toBe(true);
+            expect(result.content).toBe('Found 5 content elements');
+        });
+
+        it('should throw on non-ok response', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_tools = '/typo3/ajax/tx_cowriter_tools';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 500,
+                json: () => Promise.resolve({ error: 'Tool execution failed' }),
+            });
+
+            const service = new ServiceClass();
+            await expect(service.executeTools('Query')).rejects.toThrow(
+                'Tool execution failed'
+            );
+        });
+
+        it('should use default empty tools array', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_tools = '/typo3/ajax/tx_cowriter_tools';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({ success: true, content: 'result' }),
+            });
+
+            const service = new ServiceClass();
+            await service.executeTools('Find content');
+
+            expect(fetch).toHaveBeenCalledWith('/typo3/ajax/tx_cowriter_tools', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ prompt: 'Find content', tools: [] }),
+            });
+        });
+
+        it('should handle json parse failure in error response', async () => {
+            TYPO3Mock.settings.ajaxUrls.tx_cowriter_tools = '/typo3/ajax/tx_cowriter_tools';
+            vi.resetModules();
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            const ServiceClass = module.AIService;
+
+            globalThis.fetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 502,
+                json: () => Promise.reject(new Error('not json')),
+            });
+
+            const service = new ServiceClass();
+            await expect(service.executeTools('Query')).rejects.toThrow('Unknown error');
+        });
+    });
+
     describe('exports', () => {
         it('should not export legacy APIType or AIServiceOptions', async () => {
             const module = await import('../../Resources/Public/JavaScript/Ckeditor/AIService.js');

--- a/Tests/JavaScript/__mocks__/ckeditor5-ui.js
+++ b/Tests/JavaScript/__mocks__/ckeditor5-ui.js
@@ -1,7 +1,7 @@
 /**
  * Mock for @ckeditor/ckeditor5-ui
  *
- * Provides a minimal ButtonView stub for testing CKEditor 5 plugins.
+ * Provides minimal stubs for testing CKEditor 5 plugins.
  */
 export class ButtonView {
     constructor() {
@@ -19,9 +19,61 @@ export class ButtonView {
         this._handlers[event] = handler;
     }
 
-    fire(event) {
+    fire(event, ...args) {
         if (this._handlers[event]) {
-            return this._handlers[event]();
+            return this._handlers[event](...args);
         }
     }
+}
+
+export class Model {
+    constructor(attributes = {}) {
+        Object.assign(this, attributes);
+    }
+}
+
+export class Collection {
+    constructor() {
+        this._items = [];
+    }
+
+    add(item) {
+        this._items.push(item);
+    }
+
+    [Symbol.iterator]() {
+        return this._items[Symbol.iterator]();
+    }
+}
+
+/**
+ * Creates a mock dropdown view.
+ */
+export function createDropdown() {
+    const dropdown = {
+        _handlers: {},
+        isOpen: false,
+        buttonView: new ButtonView(),
+        on(event, handler) {
+            if (!this._handlers[event]) {
+                this._handlers[event] = [];
+            }
+            this._handlers[event].push(handler);
+        },
+        fire(event, ...args) {
+            if (this._handlers[event]) {
+                for (const handler of this._handlers[event]) {
+                    handler(...args);
+                }
+            }
+        },
+    };
+    return dropdown;
+}
+
+/**
+ * Adds list items to a dropdown.
+ */
+export function addListToDropdown(dropdown, items) {
+    dropdown._items = items;
 }

--- a/Tests/JavaScript/__mocks__/ckeditor5-ui.js
+++ b/Tests/JavaScript/__mocks__/ckeditor5-ui.js
@@ -62,10 +62,10 @@ export function createDropdown() {
         },
         fire(event, ...args) {
             if (this._handlers[event]) {
-                for (const handler of this._handlers[event]) {
-                    handler(...args);
-                }
+                const results = this._handlers[event].map(handler => handler(...args));
+                return Promise.all(results);
             }
+            return Promise.resolve();
         },
     };
     return dropdown;

--- a/Tests/JavaScript/cowriter.test.js
+++ b/Tests/JavaScript/cowriter.test.js
@@ -451,4 +451,311 @@ describe('Cowriter Plugin', () => {
             expect(addedComponents).toHaveProperty('cowriterTemplates');
         });
     });
+
+    describe('cowriterVision button', () => {
+        let plugin;
+        let mockEditor;
+        let componentCallbacks;
+        let mockAnalyzeImage;
+
+        beforeEach(async () => {
+            vi.resetModules();
+
+            mockAnalyzeImage = vi.fn().mockResolvedValue({ success: true, altText: 'A cat' });
+
+            vi.doMock('../../Resources/Public/JavaScript/Ckeditor/AIService.js', () => ({
+                AIService: class MockAIService {
+                    analyzeImage = mockAnalyzeImage;
+                },
+            }));
+            vi.doMock('../../Resources/Public/JavaScript/Ckeditor/CowriterDialog.js', () => ({
+                CowriterDialog: class MockCowriterDialog {},
+            }));
+
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/cowriter.js');
+            Cowriter = module.Cowriter;
+
+            componentCallbacks = {};
+            mockEditor = {
+                model: {
+                    document: { selection: { getFirstRange: vi.fn() } },
+                    change: vi.fn((cb) => cb(mockEditor._writer)),
+                    insertContent: vi.fn(),
+                    getSelectedContent: vi.fn(),
+                },
+                _writer: { remove: vi.fn(), insert: vi.fn(), setSelection: vi.fn() },
+                data: {
+                    processor: { toView: vi.fn().mockReturnValue({ type: 'viewFragment' }) },
+                    toModel: vi.fn().mockReturnValue({ type: 'modelFragment' }),
+                    stringify: vi.fn().mockReturnValue(''),
+                },
+                plugins: { has: vi.fn().mockReturnValue(false) },
+                config: { get: vi.fn().mockReturnValue(undefined) },
+                view: {},
+                ui: {
+                    componentFactory: {
+                        add: vi.fn((name, callback) => { componentCallbacks[name] = callback; }),
+                    },
+                },
+                getData: vi.fn().mockReturnValue(''),
+                sourceElement: null,
+            };
+
+            plugin = new Cowriter();
+            plugin.editor = mockEditor;
+            await plugin.init();
+        });
+
+        afterEach(() => {
+            vi.doUnmock('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            vi.doUnmock('../../Resources/Public/JavaScript/Ckeditor/CowriterDialog.js');
+        });
+
+        it('should create vision button with correct label', () => {
+            const button = componentCallbacks['cowriterVision']();
+            expect(button.label).toBe('Cowriter - Generate alt text');
+        });
+
+        it('should call analyzeImage and insert result', async () => {
+            // Mock window.prompt
+            globalThis.prompt = vi.fn().mockReturnValue('https://example.com/img.jpg');
+
+            const button = componentCallbacks['cowriterVision']();
+            await button.fire('execute');
+
+            expect(mockAnalyzeImage).toHaveBeenCalledWith('https://example.com/img.jpg');
+            expect(mockEditor.model.insertContent).toHaveBeenCalled();
+
+            delete globalThis.prompt;
+        });
+
+        it('should do nothing when prompt is cancelled', async () => {
+            globalThis.prompt = vi.fn().mockReturnValue(null);
+
+            const button = componentCallbacks['cowriterVision']();
+            await button.fire('execute');
+
+            expect(mockAnalyzeImage).not.toHaveBeenCalled();
+
+            delete globalThis.prompt;
+        });
+
+        it('should not execute when _isProcessing is true', async () => {
+            plugin._isProcessing = true;
+            const button = componentCallbacks['cowriterVision']();
+            await button.fire('execute');
+            expect(mockAnalyzeImage).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('cowriterTranslate dropdown', () => {
+        let plugin;
+        let mockEditor;
+        let componentCallbacks;
+        let mockTranslate;
+
+        beforeEach(async () => {
+            vi.resetModules();
+
+            mockTranslate = vi.fn().mockResolvedValue({ success: true, translation: 'Hallo Welt' });
+
+            vi.doMock('../../Resources/Public/JavaScript/Ckeditor/AIService.js', () => ({
+                AIService: class MockAIService {
+                    translate = mockTranslate;
+                },
+            }));
+            vi.doMock('../../Resources/Public/JavaScript/Ckeditor/CowriterDialog.js', () => ({
+                CowriterDialog: class MockCowriterDialog {},
+            }));
+
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/cowriter.js');
+            Cowriter = module.Cowriter;
+
+            componentCallbacks = {};
+            mockEditor = {
+                model: {
+                    document: {
+                        selection: {
+                            getFirstRange: vi.fn().mockReturnValue({ isCollapsed: false }),
+                            getFirstPosition: vi.fn().mockReturnValue({}),
+                        },
+                    },
+                    change: vi.fn((cb) => cb(mockEditor._writer)),
+                    insertContent: vi.fn(),
+                    getSelectedContent: vi.fn().mockReturnValue({ type: 'content' }),
+                },
+                _writer: { remove: vi.fn(), insert: vi.fn(), setSelection: vi.fn() },
+                data: {
+                    processor: { toView: vi.fn().mockReturnValue({ type: 'viewFragment' }) },
+                    toModel: vi.fn().mockReturnValue({ type: 'modelFragment' }),
+                    stringify: vi.fn().mockReturnValue('<p>Hello World</p>'),
+                },
+                plugins: { has: vi.fn().mockReturnValue(false) },
+                config: { get: vi.fn().mockReturnValue(undefined) },
+                view: {},
+                ui: {
+                    componentFactory: {
+                        add: vi.fn((name, callback) => { componentCallbacks[name] = callback; }),
+                    },
+                },
+                getData: vi.fn().mockReturnValue(''),
+                sourceElement: null,
+            };
+
+            plugin = new Cowriter();
+            plugin.editor = mockEditor;
+            await plugin.init();
+        });
+
+        afterEach(() => {
+            vi.doUnmock('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            vi.doUnmock('../../Resources/Public/JavaScript/Ckeditor/CowriterDialog.js');
+        });
+
+        it('should create translate dropdown with correct label', () => {
+            const dropdown = componentCallbacks['cowriterTranslate']();
+            expect(dropdown.buttonView.label).toBe('Cowriter - Translate');
+        });
+
+        it('should translate selected text on execute', async () => {
+            const dropdown = componentCallbacks['cowriterTranslate']();
+            // Simulate selecting German from dropdown
+            await dropdown.fire('execute', { source: { languageCode: 'de' } });
+
+            expect(mockTranslate).toHaveBeenCalledWith('<p>Hello World</p>', 'de');
+            expect(mockEditor.model.insertContent).toHaveBeenCalled();
+        });
+
+        it('should not translate when no text is selected', async () => {
+            mockEditor.model.document.selection.getFirstRange.mockReturnValue({ isCollapsed: true });
+            mockEditor.data.stringify.mockReturnValue('');
+
+            const dropdown = componentCallbacks['cowriterTranslate']();
+            await dropdown.fire('execute', { source: { languageCode: 'fr' } });
+
+            expect(mockTranslate).not.toHaveBeenCalled();
+        });
+
+        it('should not execute when _isProcessing is true', async () => {
+            plugin._isProcessing = true;
+            const dropdown = componentCallbacks['cowriterTranslate']();
+            await dropdown.fire('execute', { source: { languageCode: 'de' } });
+            expect(mockTranslate).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('cowriterTemplates dropdown', () => {
+        let plugin;
+        let mockEditor;
+        let componentCallbacks;
+        let mockGetTemplates;
+        let mockDialogShow;
+
+        beforeEach(async () => {
+            vi.resetModules();
+
+            mockGetTemplates = vi.fn().mockResolvedValue({
+                success: true,
+                templates: [{ identifier: 'improve', name: 'Improve', description: '' }],
+            });
+            mockDialogShow = vi.fn().mockResolvedValue({ content: 'Improved text' });
+
+            vi.doMock('../../Resources/Public/JavaScript/Ckeditor/AIService.js', () => ({
+                AIService: class MockAIService {
+                    getTemplates = mockGetTemplates;
+                },
+            }));
+            vi.doMock('../../Resources/Public/JavaScript/Ckeditor/CowriterDialog.js', () => ({
+                CowriterDialog: class MockCowriterDialog {
+                    constructor() { this.show = mockDialogShow; }
+                },
+            }));
+
+            const module = await import('../../Resources/Public/JavaScript/Ckeditor/cowriter.js');
+            Cowriter = module.Cowriter;
+
+            componentCallbacks = {};
+            mockEditor = {
+                model: {
+                    document: { selection: { getFirstRange: vi.fn() } },
+                    change: vi.fn((cb) => cb(mockEditor._writer)),
+                    insertContent: vi.fn(),
+                    getSelectedContent: vi.fn(),
+                },
+                _writer: { remove: vi.fn(), insert: vi.fn(), setSelection: vi.fn() },
+                data: {
+                    processor: { toView: vi.fn().mockReturnValue({ type: 'viewFragment' }) },
+                    toModel: vi.fn().mockReturnValue({ type: 'modelFragment' }),
+                    stringify: vi.fn().mockReturnValue(''),
+                },
+                plugins: { has: vi.fn().mockReturnValue(false) },
+                config: { get: vi.fn().mockReturnValue(undefined) },
+                view: {},
+                ui: {
+                    componentFactory: {
+                        add: vi.fn((name, callback) => { componentCallbacks[name] = callback; }),
+                    },
+                },
+                getData: vi.fn().mockReturnValue('<p>Full content</p>'),
+                sourceElement: null,
+            };
+
+            plugin = new Cowriter();
+            plugin.editor = mockEditor;
+            await plugin.init();
+        });
+
+        afterEach(() => {
+            vi.doUnmock('../../Resources/Public/JavaScript/Ckeditor/AIService.js');
+            vi.doUnmock('../../Resources/Public/JavaScript/Ckeditor/CowriterDialog.js');
+        });
+
+        it('should create templates dropdown with correct label', () => {
+            const dropdown = componentCallbacks['cowriterTemplates']();
+            expect(dropdown.buttonView.label).toBe('Cowriter - Templates');
+        });
+
+        it('should load templates on dropdown open', async () => {
+            const dropdown = componentCallbacks['cowriterTemplates']();
+            dropdown.isOpen = true;
+            await dropdown.fire('change:isOpen');
+
+            expect(mockGetTemplates).toHaveBeenCalled();
+        });
+
+        it('should not load templates when dropdown closes', async () => {
+            const dropdown = componentCallbacks['cowriterTemplates']();
+            dropdown.isOpen = false;
+            await dropdown.fire('change:isOpen');
+
+            expect(mockGetTemplates).not.toHaveBeenCalled();
+        });
+
+        it('should open dialog with template on execute', async () => {
+            const dropdown = componentCallbacks['cowriterTemplates']();
+            await dropdown.fire('execute', { source: { templateIdentifier: 'improve' } });
+
+            expect(mockDialogShow).toHaveBeenCalledWith(
+                '', '<p>Full content</p>', '', null,
+                { templateIdentifier: 'improve' },
+            );
+            expect(mockEditor.model.insertContent).toHaveBeenCalled();
+        });
+
+        it('should not insert content when dialog is cancelled', async () => {
+            mockDialogShow.mockRejectedValue(new Error('User cancelled'));
+
+            const dropdown = componentCallbacks['cowriterTemplates']();
+            await dropdown.fire('execute', { source: { templateIdentifier: 'improve' } });
+
+            expect(mockEditor.model.insertContent).not.toHaveBeenCalled();
+        });
+
+        it('should not execute when _isProcessing is true', async () => {
+            plugin._isProcessing = true;
+            const dropdown = componentCallbacks['cowriterTemplates']();
+            await dropdown.fire('execute', { source: { templateIdentifier: 'improve' } });
+            expect(mockDialogShow).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/Tests/JavaScript/cowriter.test.js
+++ b/Tests/JavaScript/cowriter.test.js
@@ -30,7 +30,7 @@ describe('Cowriter Plugin', () => {
     describe('button execute handler', () => {
         let plugin;
         let mockEditor;
-        let buttonCallback;
+        let componentCallbacks;
         let capturedButton;
         let mockDialogShow;
 
@@ -96,7 +96,8 @@ describe('Cowriter Plugin', () => {
                 ui: {
                     componentFactory: {
                         add: vi.fn((name, callback) => {
-                            buttonCallback = callback;
+                            if (!componentCallbacks) componentCallbacks = {};
+                            componentCallbacks[name] = callback;
                         }),
                     },
                 },
@@ -107,7 +108,7 @@ describe('Cowriter Plugin', () => {
             plugin = new Cowriter();
             plugin.editor = mockEditor;
             await plugin.init();
-            capturedButton = buttonCallback();
+            capturedButton = componentCallbacks['cowriter']();
         });
 
         afterEach(() => {
@@ -396,7 +397,7 @@ describe('Cowriter Plugin', () => {
         });
 
         it('should create button with correct properties', async () => {
-            let createdButton = null;
+            const createdButtons = {};
             const mockEditor = {
                 model: {
                     document: { selection: {} },
@@ -406,7 +407,7 @@ describe('Cowriter Plugin', () => {
                 ui: {
                     componentFactory: {
                         add: vi.fn((name, callback) => {
-                            createdButton = callback();
+                            createdButtons[name] = callback();
                         }),
                     },
                 },
@@ -416,10 +417,38 @@ describe('Cowriter Plugin', () => {
             plugin.editor = mockEditor;
             await plugin.init();
 
-            expect(createdButton.label).toBe('Cowriter - AI text completion');
-            expect(createdButton.tooltip).toBe(true);
-            expect(createdButton.icon).toContain('svg');
-            expect(createdButton.icon).toContain('aria-hidden="true"');
+            const cowriterButton = createdButtons['cowriter'];
+            expect(cowriterButton.label).toBe('Cowriter - AI text completion');
+            expect(cowriterButton.tooltip).toBe(true);
+            expect(cowriterButton.icon).toContain('svg');
+            expect(cowriterButton.icon).toContain('aria-hidden="true"');
+        });
+
+        it('should register all four toolbar components', async () => {
+            const addedComponents = {};
+            const mockEditor = {
+                model: {
+                    document: { selection: {} },
+                    change: vi.fn(),
+                },
+                view: {},
+                ui: {
+                    componentFactory: {
+                        add: vi.fn((name, callback) => {
+                            addedComponents[name] = callback;
+                        }),
+                    },
+                },
+            };
+
+            const plugin = new Cowriter();
+            plugin.editor = mockEditor;
+            await plugin.init();
+
+            expect(addedComponents).toHaveProperty('cowriter');
+            expect(addedComponents).toHaveProperty('cowriterVision');
+            expect(addedComponents).toHaveProperty('cowriterTranslate');
+            expect(addedComponents).toHaveProperty('cowriterTemplates');
         });
     });
 });

--- a/Tests/JavaScript/cowriter.test.js
+++ b/Tests/JavaScript/cowriter.test.js
@@ -478,12 +478,12 @@ describe('Cowriter Plugin', () => {
             componentCallbacks = {};
             mockEditor = {
                 model: {
-                    document: { selection: { getFirstRange: vi.fn() } },
+                    document: { selection: { getFirstRange: vi.fn(), getFirstPosition: vi.fn() } },
                     change: vi.fn((cb) => cb(mockEditor._writer)),
                     insertContent: vi.fn(),
                     getSelectedContent: vi.fn(),
                 },
-                _writer: { remove: vi.fn(), insert: vi.fn(), setSelection: vi.fn() },
+                _writer: { remove: vi.fn(), insert: vi.fn(), insertText: vi.fn(), setSelection: vi.fn() },
                 data: {
                     processor: { toView: vi.fn().mockReturnValue({ type: 'viewFragment' }) },
                     toModel: vi.fn().mockReturnValue({ type: 'modelFragment' }),
@@ -524,7 +524,8 @@ describe('Cowriter Plugin', () => {
             await button.fire('execute');
 
             expect(mockAnalyzeImage).toHaveBeenCalledWith('https://example.com/img.jpg');
-            expect(mockEditor.model.insertContent).toHaveBeenCalled();
+            expect(mockEditor.model.change).toHaveBeenCalled();
+            expect(mockEditor._writer.insertText).toHaveBeenCalledWith('A cat', undefined);
 
             delete globalThis.prompt;
         });
@@ -584,7 +585,7 @@ describe('Cowriter Plugin', () => {
                     insertContent: vi.fn(),
                     getSelectedContent: vi.fn().mockReturnValue({ type: 'content' }),
                 },
-                _writer: { remove: vi.fn(), insert: vi.fn(), setSelection: vi.fn() },
+                _writer: { remove: vi.fn(), insert: vi.fn(), insertText: vi.fn(), setSelection: vi.fn() },
                 data: {
                     processor: { toView: vi.fn().mockReturnValue({ type: 'viewFragment' }) },
                     toModel: vi.fn().mockReturnValue({ type: 'modelFragment' }),
@@ -677,12 +678,12 @@ describe('Cowriter Plugin', () => {
             componentCallbacks = {};
             mockEditor = {
                 model: {
-                    document: { selection: { getFirstRange: vi.fn() } },
+                    document: { selection: { getFirstRange: vi.fn(), getFirstPosition: vi.fn() } },
                     change: vi.fn((cb) => cb(mockEditor._writer)),
                     insertContent: vi.fn(),
                     getSelectedContent: vi.fn(),
                 },
-                _writer: { remove: vi.fn(), insert: vi.fn(), setSelection: vi.fn() },
+                _writer: { remove: vi.fn(), insert: vi.fn(), insertText: vi.fn(), setSelection: vi.fn() },
                 data: {
                     processor: { toView: vi.fn().mockReturnValue({ type: 'viewFragment' }) },
                     toModel: vi.fn().mockReturnValue({ type: 'modelFragment' }),

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -2401,6 +2401,7 @@ final class AjaxControllerTest extends TestCase
             ->with(
                 $this->callback(static function (array $messages): bool {
                     $userMsg = $messages[count($messages) - 1];
+
                     // Whitespace-only ad-hoc rules should be skipped — no ADDITIONAL RULES prefix
                     return $userMsg['role'] === 'user'
                         && !str_contains($userMsg['content'], 'ADDITIONAL RULES');

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -2341,6 +2341,84 @@ final class AjaxControllerTest extends TestCase
         return $mock;
     }
 
+    #[Test]
+    public function executeTaskActionSkipsCapabilitiesWhenWhitespaceOnly(): void
+    {
+        $task = $this->createTaskMock(1, 'improve', 'Improve', 'desc', true);
+        $task->method('buildPrompt')->willReturn('Improve: text');
+        $task->method('getConfiguration')->willReturn(null);
+
+        $this->taskRepositoryMock->method('findByUid')->willReturn($task);
+
+        $config = $this->createConfigurationMock();
+        $this->configRepositoryMock->method('findDefault')->willReturn($config);
+
+        $completionResponse = $this->createCompletionResponse('Result');
+
+        $this->llmServiceManagerMock
+            ->expects($this->once())
+            ->method('chatWithConfiguration')
+            ->with(
+                $this->callback(static function (array $messages): bool {
+                    // Whitespace-only capabilities should be skipped: [0] = scope, [1] = user
+                    return count($messages) === 2
+                        && $messages[0]['role'] === 'system'
+                        && $messages[1]['role'] === 'user';
+                }),
+                $config,
+            )
+            ->willReturn($completionResponse);
+
+        $request = $this->createRequestWithJsonBody([
+            'taskUid'            => 1,
+            'context'            => 'text',
+            'contextType'        => 'selection',
+            'editorCapabilities' => '   ',
+        ]);
+
+        $this->subject->executeTaskAction($request);
+    }
+
+    #[Test]
+    public function executeTaskActionSkipsAdHocRulesWhenWhitespaceOnly(): void
+    {
+        $task = $this->createTaskMock(1, 'improve', 'Improve', 'desc', true);
+        $task->method('buildPrompt')->willReturnCallback(
+            static fn (array $vars) => 'Improve: ' . ($vars['input'] ?? 'text'),
+        );
+        $task->method('getConfiguration')->willReturn(null);
+
+        $this->taskRepositoryMock->method('findByUid')->willReturn($task);
+
+        $config = $this->createConfigurationMock();
+        $this->configRepositoryMock->method('findDefault')->willReturn($config);
+
+        $completionResponse = $this->createCompletionResponse('Result');
+
+        $this->llmServiceManagerMock
+            ->expects($this->once())
+            ->method('chatWithConfiguration')
+            ->with(
+                $this->callback(static function (array $messages): bool {
+                    $userMsg = $messages[count($messages) - 1];
+                    // Whitespace-only ad-hoc rules should be skipped — no ADDITIONAL RULES prefix
+                    return $userMsg['role'] === 'user'
+                        && !str_contains($userMsg['content'], 'ADDITIONAL RULES');
+                }),
+                $config,
+            )
+            ->willReturn($completionResponse);
+
+        $request = $this->createRequestWithJsonBody([
+            'taskUid'     => 1,
+            'context'     => 'text',
+            'contextType' => 'selection',
+            'adHocRules'  => '   ',
+        ]);
+
+        $this->subject->executeTaskAction($request);
+    }
+
     private function createConfigurationMock(
         string $identifier = 'default',
         string $name = 'Default Config',

--- a/Tests/Unit/Controller/TemplateControllerTest.php
+++ b/Tests/Unit/Controller/TemplateControllerTest.php
@@ -67,11 +67,14 @@ final class TemplateControllerTest extends TestCase
         $request  = $this->createStub(ServerRequestInterface::class);
         $response = $this->subject->listAction($request);
 
+        self::assertSame(200, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertTrue($data['success']);
         self::assertCount(1, $data['templates']);
         self::assertSame('improve', $data['templates'][0]['identifier']);
         self::assertSame('Improve Text', $data['templates'][0]['name']);
+        self::assertSame('Enhance readability', $data['templates'][0]['description']);
+        self::assertSame('content', $data['templates'][0]['category']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
@@ -87,6 +90,9 @@ final class TemplateControllerTest extends TestCase
         $response = $this->subject->listAction($request);
 
         self::assertSame(429, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+        self::assertArrayHasKey('error', $data);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('0', $response->getHeaderLine('X-RateLimit-Remaining'));
         self::assertNotEmpty($response->getHeaderLine('Retry-After'));
@@ -107,6 +113,8 @@ final class TemplateControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+        self::assertArrayHasKey('error', $data);
+        self::assertStringContainsString('Failed', $data['error']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
@@ -128,6 +136,29 @@ final class TemplateControllerTest extends TestCase
         self::assertSame([], $data['templates']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
+    }
+
+    #[Test]
+    public function listActionCoalescesNullDescriptionToEmptyString(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $template = $this->createStub(PromptTemplate::class);
+        $template->method('getIdentifier')->willReturn('no-desc');
+        $template->method('getTitle')->willReturn('No Description');
+        $template->method('getDescription')->willReturn(null);
+        $template->method('getFeature')->willReturn('misc');
+
+        $this->templateRepositoryStub->method('findActive')
+            ->willReturn($this->createQueryResult([$template]));
+
+        $request  = $this->createStub(ServerRequestInterface::class);
+        $response = $this->subject->listAction($request);
+
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertSame('', $data['templates'][0]['description']);
+        self::assertSame('misc', $data['templates'][0]['category']);
     }
 
     /**

--- a/Tests/Unit/Controller/TemplateControllerTest.php
+++ b/Tests/Unit/Controller/TemplateControllerTest.php
@@ -13,6 +13,8 @@ use ArrayIterator;
 use Netresearch\NrLlm\Domain\Model\PromptTemplate;
 use Netresearch\NrLlm\Domain\Repository\PromptTemplateRepository;
 use Netresearch\T3Cowriter\Controller\TemplateController;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
@@ -20,20 +22,29 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
-use stdClass;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
 #[CoversClass(TemplateController::class)]
 final class TemplateControllerTest extends TestCase
 {
-    private PromptTemplateRepository&Stub $templateRepoStub;
+    private PromptTemplateRepository&Stub $templateRepositoryStub;
+    private RateLimiterInterface&Stub $rateLimiterStub;
     private TemplateController $subject;
 
     protected function setUp(): void
     {
-        $this->templateRepoStub = $this->createStub(PromptTemplateRepository::class);
-        $this->subject          = new TemplateController(
-            $this->templateRepoStub,
+        $this->templateRepositoryStub = $this->createStub(PromptTemplateRepository::class);
+        $this->rateLimiterStub        = $this->createStub(RateLimiterInterface::class);
+        $contextStub                  = $this->createStub(Context::class);
+
+        $contextStub->method('getPropertyFromAspect')
+            ->willReturn(1);
+
+        $this->subject = new TemplateController(
+            $this->templateRepositoryStub,
+            $this->rateLimiterStub,
+            $contextStub,
             new NullLogger(),
         );
     }
@@ -41,13 +52,16 @@ final class TemplateControllerTest extends TestCase
     #[Test]
     public function listActionReturnsTemplates(): void
     {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
         $template = $this->createStub(PromptTemplate::class);
-        $template->method('getIdentifier')->willReturn('blog_post');
-        $template->method('getTitle')->willReturn('Blog Post');
-        $template->method('getDescription')->willReturn('Generate a blog post');
+        $template->method('getIdentifier')->willReturn('improve');
+        $template->method('getTitle')->willReturn('Improve Text');
+        $template->method('getDescription')->willReturn('Enhance readability');
         $template->method('getFeature')->willReturn('content');
 
-        $this->templateRepoStub->method('findActive')
+        $this->templateRepositoryStub->method('findActive')
             ->willReturn($this->createQueryResult([$template]));
 
         $request  = $this->createStub(ServerRequestInterface::class);
@@ -56,28 +70,33 @@ final class TemplateControllerTest extends TestCase
         $data = json_decode((string) $response->getBody(), true);
         self::assertTrue($data['success']);
         self::assertCount(1, $data['templates']);
-        self::assertSame('blog_post', $data['templates'][0]['identifier']);
-        self::assertSame('Blog Post', $data['templates'][0]['name']);
+        self::assertSame('improve', $data['templates'][0]['identifier']);
+        self::assertSame('Improve Text', $data['templates'][0]['name']);
     }
 
     #[Test]
-    public function listActionReturnsEmptyArrayWhenNoTemplates(): void
+    public function listActionReturns429WithHeadersWhenRateLimited(): void
     {
-        $this->templateRepoStub->method('findActive')
-            ->willReturn($this->createQueryResult([]));
+        $resetTime = time() + 60;
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(false, 20, 0, $resetTime));
 
         $request  = $this->createStub(ServerRequestInterface::class);
         $response = $this->subject->listAction($request);
 
-        $data = json_decode((string) $response->getBody(), true);
-        self::assertTrue($data['success']);
-        self::assertCount(0, $data['templates']);
+        self::assertSame(429, $response->getStatusCode());
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('0', $response->getHeaderLine('X-RateLimit-Remaining'));
+        self::assertNotEmpty($response->getHeaderLine('Retry-After'));
     }
 
     #[Test]
-    public function listActionReturns500OnError(): void
+    public function listActionReturns500OnRepositoryError(): void
     {
-        $this->templateRepoStub->method('findActive')
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $this->templateRepositoryStub->method('findActive')
             ->willThrowException(new RuntimeException('DB error'));
 
         $request  = $this->createStub(ServerRequestInterface::class);
@@ -89,39 +108,46 @@ final class TemplateControllerTest extends TestCase
     }
 
     #[Test]
-    public function listActionSkipsNonTemplateObjects(): void
+    public function listActionReturnsEmptyArrayWhenNoTemplates(): void
     {
-        $template = $this->createStub(PromptTemplate::class);
-        $template->method('getIdentifier')->willReturn('valid');
-        $template->method('getTitle')->willReturn('Valid');
-        $template->method('getDescription')->willReturn('desc');
-        $template->method('getFeature')->willReturn('cat');
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
 
-        // Mix in a non-PromptTemplate object
-        $this->templateRepoStub->method('findActive')
-            ->willReturn($this->createQueryResult([new stdClass(), $template]));
+        $this->templateRepositoryStub->method('findActive')
+            ->willReturn($this->createQueryResult([]));
 
         $request  = $this->createStub(ServerRequestInterface::class);
         $response = $this->subject->listAction($request);
 
         $data = json_decode((string) $response->getBody(), true);
-        self::assertCount(1, $data['templates']);
+        self::assertTrue($data['success']);
+        self::assertSame([], $data['templates']);
     }
 
     /**
-     * @param list<object> $items
+     * @param list<PromptTemplate&Stub> $items
      */
     private function createQueryResult(array $items): QueryResultInterface&Stub
     {
-        $queryResult = $this->createStub(QueryResultInterface::class);
         $iterator    = new ArrayIterator($items);
+        $queryResult = $this->createStub(QueryResultInterface::class);
 
-        $queryResult->method('current')->willReturnCallback(static fn () => $iterator->current());
-        $queryResult->method('key')->willReturnCallback(static fn () => $iterator->key());
-        $queryResult->method('next')->willReturnCallback(static fn () => $iterator->next());
-        $queryResult->method('rewind')->willReturnCallback(static fn () => $iterator->rewind());
-        $queryResult->method('valid')->willReturnCallback(static fn () => $iterator->valid());
-        $queryResult->method('count')->willReturn(count($items));
+        $queryResult->method('current')
+            ->willReturnCallback(static fn () => $iterator->current());
+        $queryResult->method('next')
+            ->willReturnCallback(static function () use ($iterator): void {
+                $iterator->next();
+            });
+        $queryResult->method('key')
+            ->willReturnCallback(static fn () => $iterator->key());
+        $queryResult->method('valid')
+            ->willReturnCallback(static fn (): bool => $iterator->valid());
+        $queryResult->method('rewind')
+            ->willReturnCallback(static function () use ($iterator): void {
+                $iterator->rewind();
+            });
+        $queryResult->method('count')
+            ->willReturn(count($items));
 
         return $queryResult;
     }

--- a/Tests/Unit/Controller/TemplateControllerTest.php
+++ b/Tests/Unit/Controller/TemplateControllerTest.php
@@ -72,6 +72,8 @@ final class TemplateControllerTest extends TestCase
         self::assertCount(1, $data['templates']);
         self::assertSame('improve', $data['templates'][0]['identifier']);
         self::assertSame('Improve Text', $data['templates'][0]['name']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -105,6 +107,8 @@ final class TemplateControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -122,6 +126,8 @@ final class TemplateControllerTest extends TestCase
         $data = json_decode((string) $response->getBody(), true);
         self::assertTrue($data['success']);
         self::assertSame([], $data['templates']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     /**

--- a/Tests/Unit/Controller/TemplateControllerTest.php
+++ b/Tests/Unit/Controller/TemplateControllerTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
+
+use ArrayIterator;
+use Netresearch\NrLlm\Domain\Model\PromptTemplate;
+use Netresearch\NrLlm\Domain\Repository\PromptTemplateRepository;
+use Netresearch\T3Cowriter\Controller\TemplateController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use stdClass;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+#[CoversClass(TemplateController::class)]
+final class TemplateControllerTest extends TestCase
+{
+    private PromptTemplateRepository&Stub $templateRepoStub;
+    private TemplateController $subject;
+
+    protected function setUp(): void
+    {
+        $this->templateRepoStub = $this->createStub(PromptTemplateRepository::class);
+        $this->subject          = new TemplateController(
+            $this->templateRepoStub,
+            new NullLogger(),
+        );
+    }
+
+    #[Test]
+    public function listActionReturnsTemplates(): void
+    {
+        $template = $this->createStub(PromptTemplate::class);
+        $template->method('getIdentifier')->willReturn('blog_post');
+        $template->method('getTitle')->willReturn('Blog Post');
+        $template->method('getDescription')->willReturn('Generate a blog post');
+        $template->method('getFeature')->willReturn('content');
+
+        $this->templateRepoStub->method('findActive')
+            ->willReturn($this->createQueryResult([$template]));
+
+        $request  = $this->createStub(ServerRequestInterface::class);
+        $response = $this->subject->listAction($request);
+
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertTrue($data['success']);
+        self::assertCount(1, $data['templates']);
+        self::assertSame('blog_post', $data['templates'][0]['identifier']);
+        self::assertSame('Blog Post', $data['templates'][0]['name']);
+    }
+
+    #[Test]
+    public function listActionReturnsEmptyArrayWhenNoTemplates(): void
+    {
+        $this->templateRepoStub->method('findActive')
+            ->willReturn($this->createQueryResult([]));
+
+        $request  = $this->createStub(ServerRequestInterface::class);
+        $response = $this->subject->listAction($request);
+
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertTrue($data['success']);
+        self::assertCount(0, $data['templates']);
+    }
+
+    #[Test]
+    public function listActionReturns500OnError(): void
+    {
+        $this->templateRepoStub->method('findActive')
+            ->willThrowException(new RuntimeException('DB error'));
+
+        $request  = $this->createStub(ServerRequestInterface::class);
+        $response = $this->subject->listAction($request);
+
+        self::assertSame(500, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+    }
+
+    #[Test]
+    public function listActionSkipsNonTemplateObjects(): void
+    {
+        $template = $this->createStub(PromptTemplate::class);
+        $template->method('getIdentifier')->willReturn('valid');
+        $template->method('getTitle')->willReturn('Valid');
+        $template->method('getDescription')->willReturn('desc');
+        $template->method('getFeature')->willReturn('cat');
+
+        // Mix in a non-PromptTemplate object
+        $this->templateRepoStub->method('findActive')
+            ->willReturn($this->createQueryResult([new stdClass(), $template]));
+
+        $request  = $this->createStub(ServerRequestInterface::class);
+        $response = $this->subject->listAction($request);
+
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertCount(1, $data['templates']);
+    }
+
+    /**
+     * @param list<object> $items
+     */
+    private function createQueryResult(array $items): QueryResultInterface&Stub
+    {
+        $queryResult = $this->createStub(QueryResultInterface::class);
+        $iterator    = new ArrayIterator($items);
+
+        $queryResult->method('current')->willReturnCallback(static fn () => $iterator->current());
+        $queryResult->method('key')->willReturnCallback(static fn () => $iterator->key());
+        $queryResult->method('next')->willReturnCallback(static fn () => $iterator->next());
+        $queryResult->method('rewind')->willReturnCallback(static fn () => $iterator->rewind());
+        $queryResult->method('valid')->willReturnCallback(static fn () => $iterator->valid());
+        $queryResult->method('count')->willReturn(count($items));
+
+        return $queryResult;
+    }
+}

--- a/Tests/Unit/Controller/ToolControllerTest.php
+++ b/Tests/Unit/Controller/ToolControllerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\T3Cowriter\Controller\ToolController;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Context\Context;
+
+#[CoversClass(ToolController::class)]
+final class ToolControllerTest extends TestCase
+{
+    private LlmServiceManagerInterface&Stub $llmServiceManagerStub;
+    private RateLimiterInterface&Stub $rateLimiterStub;
+    private ToolController $subject;
+
+    protected function setUp(): void
+    {
+        $this->llmServiceManagerStub = $this->createStub(LlmServiceManagerInterface::class);
+        $this->rateLimiterStub       = $this->createStub(RateLimiterInterface::class);
+        $contextStub                 = $this->createStub(Context::class);
+
+        $contextStub->method('getPropertyFromAspect')
+            ->willReturn(1);
+
+        $this->subject = new ToolController(
+            $this->llmServiceManagerStub,
+            $this->rateLimiterStub,
+            $contextStub,
+            new NullLogger(),
+        );
+    }
+
+    #[Test]
+    public function executeActionReturnsRateLimitResponse(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(false, 20, 0, time() + 60));
+
+        $request  = $this->createJsonRequest(['prompt' => 'Find all text elements']);
+        $response = $this->subject->executeAction($request);
+
+        self::assertSame(429, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function executeActionReturnsBadRequestForMissingPrompt(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $request  = $this->createJsonRequest([]);
+        $response = $this->subject->executeAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+    }
+
+    #[Test]
+    public function executeActionReturnsToolCallResult(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $completionResponse = new CompletionResponse(
+            content: 'Here are the content elements on page 1.',
+            model: 'gpt-4',
+            usage: new UsageStatistics(100, 50, 150),
+            finishReason: 'stop',
+            provider: 'openai',
+            toolCalls: null,
+            metadata: null,
+        );
+
+        $this->llmServiceManagerStub->method('chatWithTools')
+            ->willReturn($completionResponse);
+
+        $request  = $this->createJsonRequest(['prompt' => 'Find all text elements']);
+        $response = $this->subject->executeAction($request);
+
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertTrue($data['success']);
+        self::assertSame('Here are the content elements on page 1.', $data['content']);
+        self::assertSame('stop', $data['finishReason']);
+        self::assertSame(100, $data['usage']['promptTokens']);
+        self::assertSame(50, $data['usage']['completionTokens']);
+        self::assertSame(150, $data['usage']['totalTokens']);
+    }
+
+    #[Test]
+    public function executeActionReturnsErrorOnException(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $this->llmServiceManagerStub->method('chatWithTools')
+            ->willThrowException(new RuntimeException('API error'));
+
+        $request  = $this->createJsonRequest(['prompt' => 'Find all text elements']);
+        $response = $this->subject->executeAction($request);
+
+        self::assertSame(500, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+    }
+
+    private function createJsonRequest(array $body): ServerRequestInterface&Stub
+    {
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn($body);
+
+        return $request;
+    }
+}

--- a/Tests/Unit/Controller/ToolControllerTest.php
+++ b/Tests/Unit/Controller/ToolControllerTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use TYPO3\CMS\Core\Context\Context;
@@ -49,15 +50,19 @@ final class ToolControllerTest extends TestCase
     }
 
     #[Test]
-    public function executeActionReturnsRateLimitResponse(): void
+    public function executeActionReturns429WithHeadersWhenRateLimited(): void
     {
+        $resetTime = time() + 60;
         $this->rateLimiterStub->method('checkLimit')
-            ->willReturn(new RateLimitResult(false, 20, 0, time() + 60));
+            ->willReturn(new RateLimitResult(false, 20, 0, $resetTime));
 
         $request  = $this->createJsonRequest(['prompt' => 'Find all text elements']);
         $response = $this->subject->executeAction($request);
 
         self::assertSame(429, $response->getStatusCode());
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('0', $response->getHeaderLine('X-RateLimit-Remaining'));
+        self::assertNotEmpty($response->getHeaderLine('Retry-After'));
     }
 
     #[Test]
@@ -72,6 +77,20 @@ final class ToolControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+    }
+
+    #[Test]
+    public function executeActionReturns400ForInvalidJson(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $request  = $this->createRawRequest('not json');
+        $response = $this->subject->executeAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertStringContainsString('Invalid JSON', $data['error']);
     }
 
     #[Test]
@@ -106,6 +125,35 @@ final class ToolControllerTest extends TestCase
     }
 
     #[Test]
+    public function executeActionUsesRequestedToolsFromAllowList(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $completionResponse = new CompletionResponse(
+            content: 'Result',
+            model: 'gpt-4',
+            usage: new UsageStatistics(10, 5, 15),
+            finishReason: 'stop',
+            provider: 'openai',
+            toolCalls: null,
+            metadata: null,
+        );
+
+        $this->llmServiceManagerStub->method('chatWithTools')
+            ->willReturn($completionResponse);
+
+        $request = $this->createJsonRequest([
+            'prompt' => 'Query content',
+            'tools'  => ['contentQuery'],
+        ]);
+        $response = $this->subject->executeAction($request);
+
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertTrue($data['success']);
+    }
+
+    #[Test]
     public function executeActionReturnsErrorOnException(): void
     {
         $this->rateLimiterStub->method('checkLimit')
@@ -122,10 +170,21 @@ final class ToolControllerTest extends TestCase
         self::assertFalse($data['success']);
     }
 
+    /**
+     * @param array<string, mixed> $body
+     */
     private function createJsonRequest(array $body): ServerRequestInterface&Stub
     {
+        return $this->createRawRequest(json_encode($body, JSON_THROW_ON_ERROR));
+    }
+
+    private function createRawRequest(string $rawBody): ServerRequestInterface&Stub
+    {
+        $stream = $this->createStub(StreamInterface::class);
+        $stream->method('__toString')->willReturn($rawBody);
+
         $request = $this->createStub(ServerRequestInterface::class);
-        $request->method('getParsedBody')->willReturn($body);
+        $request->method('getBody')->willReturn($stream);
 
         return $request;
     }

--- a/Tests/Unit/Controller/ToolControllerTest.php
+++ b/Tests/Unit/Controller/ToolControllerTest.php
@@ -60,6 +60,9 @@ final class ToolControllerTest extends TestCase
         $response = $this->subject->executeAction($request);
 
         self::assertSame(429, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+        self::assertArrayHasKey('error', $data);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('0', $response->getHeaderLine('X-RateLimit-Remaining'));
         self::assertNotEmpty($response->getHeaderLine('Retry-After'));
@@ -77,6 +80,7 @@ final class ToolControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+        self::assertStringContainsString('Missing', $data['error']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
@@ -92,6 +96,7 @@ final class ToolControllerTest extends TestCase
 
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
         self::assertStringContainsString('Invalid JSON', $data['error']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
@@ -119,10 +124,13 @@ final class ToolControllerTest extends TestCase
         $request  = $this->createJsonRequest(['prompt' => 'Find all text elements']);
         $response = $this->subject->executeAction($request);
 
+        self::assertSame(200, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertTrue($data['success']);
         self::assertSame('Here are the content elements on page 1.', $data['content']);
+        self::assertArrayHasKey('toolCalls', $data);
         self::assertSame('stop', $data['finishReason']);
+        self::assertArrayHasKey('usage', $data);
         self::assertSame(100, $data['usage']['promptTokens']);
         self::assertSame(50, $data['usage']['completionTokens']);
         self::assertSame(150, $data['usage']['totalTokens']);
@@ -189,6 +197,8 @@ final class ToolControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+        self::assertArrayHasKey('error', $data);
+        self::assertStringContainsString('failed', $data['error']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }

--- a/Tests/Unit/Controller/ToolControllerTest.php
+++ b/Tests/Unit/Controller/ToolControllerTest.php
@@ -77,6 +77,8 @@ final class ToolControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -91,6 +93,8 @@ final class ToolControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertStringContainsString('Invalid JSON', $data['error']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -122,6 +126,8 @@ final class ToolControllerTest extends TestCase
         self::assertSame(100, $data['usage']['promptTokens']);
         self::assertSame(50, $data['usage']['completionTokens']);
         self::assertSame(150, $data['usage']['totalTokens']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -145,12 +151,27 @@ final class ToolControllerTest extends TestCase
 
         $request = $this->createJsonRequest([
             'prompt' => 'Query content',
-            'tools'  => ['contentQuery'],
+            'tools'  => ['query_content'],
         ]);
         $response = $this->subject->executeAction($request);
 
         $data = json_decode((string) $response->getBody(), true);
         self::assertTrue($data['success']);
+    }
+
+    #[Test]
+    public function executeActionReturnsBadRequestForExcessivePromptLength(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $request  = $this->createJsonRequest(['prompt' => str_repeat('a', 40000)]);
+        $response = $this->subject->executeAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+        self::assertStringContainsString('fields exceed maximum length', $data['error']);
     }
 
     #[Test]
@@ -168,6 +189,8 @@ final class ToolControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     /**

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use TYPO3\CMS\Core\Context\Context;
@@ -100,15 +101,48 @@ final class TranslationControllerTest extends TestCase
     }
 
     #[Test]
-    public function translateActionReturns429WhenRateLimited(): void
+    public function translateActionReturns429WithHeadersWhenRateLimited(): void
     {
+        $resetTime = time() + 60;
         $this->rateLimiterStub->method('checkLimit')
-            ->willReturn(new RateLimitResult(false, 20, 0, time() + 60));
+            ->willReturn(new RateLimitResult(false, 20, 0, $resetTime));
 
         $request  = $this->createJsonRequest(['text' => 'Hello', 'targetLanguage' => 'de']);
         $response = $this->subject->translateAction($request);
 
         self::assertSame(429, $response->getStatusCode());
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('0', $response->getHeaderLine('X-RateLimit-Remaining'));
+        self::assertNotEmpty($response->getHeaderLine('Retry-After'));
+    }
+
+    #[Test]
+    public function translateActionReturns400ForInvalidJson(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $request  = $this->createRawRequest('{bad json');
+        $response = $this->subject->translateAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertStringContainsString('Invalid JSON', $data['error']);
+    }
+
+    #[Test]
+    public function translateActionReturns400ForExcessiveFieldLength(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $longText = str_repeat('a', 40000);
+        $request  = $this->createJsonRequest(['text' => $longText, 'targetLanguage' => 'de']);
+        $response = $this->subject->translateAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertStringContainsString('maximum length', $data['error']);
     }
 
     #[Test]
@@ -126,10 +160,21 @@ final class TranslationControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
     }
 
+    /**
+     * @param array<string, mixed> $body
+     */
     private function createJsonRequest(array $body): ServerRequestInterface&Stub
     {
+        return $this->createRawRequest(json_encode($body, JSON_THROW_ON_ERROR));
+    }
+
+    private function createRawRequest(string $rawBody): ServerRequestInterface&Stub
+    {
+        $stream = $this->createStub(StreamInterface::class);
+        $stream->method('__toString')->willReturn($rawBody);
+
         $request = $this->createStub(ServerRequestInterface::class);
-        $request->method('getParsedBody')->willReturn($body);
+        $request->method('getBody')->willReturn($stream);
 
         return $request;
     }

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -69,11 +69,16 @@ final class TranslationControllerTest extends TestCase
         $request  = $this->createJsonRequest(['text' => 'Hello world', 'targetLanguage' => 'de']);
         $response = $this->subject->translateAction($request);
 
+        self::assertSame(200, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertTrue($data['success']);
         self::assertSame('Hallo Welt', $data['translation']);
         self::assertSame('en', $data['sourceLanguage']);
         self::assertSame(0.9, $data['confidence']);
+        self::assertArrayHasKey('usage', $data);
+        self::assertSame(50, $data['usage']['promptTokens']);
+        self::assertSame(30, $data['usage']['completionTokens']);
+        self::assertSame(80, $data['usage']['totalTokens']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
@@ -88,6 +93,9 @@ final class TranslationControllerTest extends TestCase
         $response = $this->subject->translateAction($request);
 
         self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+        self::assertStringContainsString('Missing', $data['error']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
@@ -102,6 +110,9 @@ final class TranslationControllerTest extends TestCase
         $response = $this->subject->translateAction($request);
 
         self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+        self::assertStringContainsString('Missing', $data['error']);
     }
 
     #[Test]
@@ -115,6 +126,9 @@ final class TranslationControllerTest extends TestCase
         $response = $this->subject->translateAction($request);
 
         self::assertSame(429, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+        self::assertArrayHasKey('error', $data);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('0', $response->getHeaderLine('X-RateLimit-Remaining'));
         self::assertNotEmpty($response->getHeaderLine('Retry-After'));
@@ -131,6 +145,7 @@ final class TranslationControllerTest extends TestCase
 
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
         self::assertStringContainsString('Invalid JSON', $data['error']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
@@ -148,6 +163,7 @@ final class TranslationControllerTest extends TestCase
 
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
         self::assertStringContainsString('maximum length', $data['error']);
     }
 
@@ -164,6 +180,10 @@ final class TranslationControllerTest extends TestCase
         $response = $this->subject->translateAction($request);
 
         self::assertSame(500, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+        self::assertArrayHasKey('error', $data);
+        self::assertStringContainsString('failed', $data['error']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
+
+use Netresearch\NrLlm\Domain\Model\TranslationResult;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Service\Feature\TranslationService;
+use Netresearch\T3Cowriter\Controller\TranslationController;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Context\Context;
+
+#[CoversClass(TranslationController::class)]
+final class TranslationControllerTest extends TestCase
+{
+    private TranslationService&Stub $translationServiceStub;
+    private RateLimiterInterface&Stub $rateLimiterStub;
+    private TranslationController $subject;
+
+    protected function setUp(): void
+    {
+        $this->translationServiceStub = $this->createStub(TranslationService::class);
+        $this->rateLimiterStub        = $this->createStub(RateLimiterInterface::class);
+        $contextStub                  = $this->createStub(Context::class);
+
+        $contextStub->method('getPropertyFromAspect')
+            ->willReturn(1);
+
+        $this->subject = new TranslationController(
+            $this->translationServiceStub,
+            $this->rateLimiterStub,
+            $contextStub,
+            new NullLogger(),
+        );
+    }
+
+    #[Test]
+    public function translateActionReturnsTranslation(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $translationResult = new TranslationResult(
+            translation: 'Hallo Welt',
+            sourceLanguage: 'en',
+            targetLanguage: 'de',
+            confidence: 0.9,
+            usage: new UsageStatistics(50, 30, 80),
+        );
+
+        $this->translationServiceStub->method('translate')
+            ->willReturn($translationResult);
+
+        $request  = $this->createJsonRequest(['text' => 'Hello world', 'targetLanguage' => 'de']);
+        $response = $this->subject->translateAction($request);
+
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertTrue($data['success']);
+        self::assertSame('Hallo Welt', $data['translation']);
+        self::assertSame('en', $data['sourceLanguage']);
+        self::assertSame(0.9, $data['confidence']);
+    }
+
+    #[Test]
+    public function translateActionReturns400ForMissingText(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $request  = $this->createJsonRequest(['targetLanguage' => 'de']);
+        $response = $this->subject->translateAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function translateActionReturns400ForMissingTargetLanguage(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $request  = $this->createJsonRequest(['text' => 'Hello']);
+        $response = $this->subject->translateAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function translateActionReturns429WhenRateLimited(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(false, 20, 0, time() + 60));
+
+        $request  = $this->createJsonRequest(['text' => 'Hello', 'targetLanguage' => 'de']);
+        $response = $this->subject->translateAction($request);
+
+        self::assertSame(429, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function translateActionReturns500OnServiceError(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $this->translationServiceStub->method('translate')
+            ->willThrowException(new RuntimeException('API error'));
+
+        $request  = $this->createJsonRequest(['text' => 'Hello', 'targetLanguage' => 'de']);
+        $response = $this->subject->translateAction($request);
+
+        self::assertSame(500, $response->getStatusCode());
+    }
+
+    private function createJsonRequest(array $body): ServerRequestInterface&Stub
+    {
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn($body);
+
+        return $request;
+    }
+}

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -74,6 +74,8 @@ final class TranslationControllerTest extends TestCase
         self::assertSame('Hallo Welt', $data['translation']);
         self::assertSame('en', $data['sourceLanguage']);
         self::assertSame(0.9, $data['confidence']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -86,6 +88,8 @@ final class TranslationControllerTest extends TestCase
         $response = $this->subject->translateAction($request);
 
         self::assertSame(400, $response->getStatusCode());
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -128,6 +132,8 @@ final class TranslationControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertStringContainsString('Invalid JSON', $data['error']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -158,6 +164,8 @@ final class TranslationControllerTest extends TestCase
         $response = $this->subject->translateAction($request);
 
         self::assertSame(500, $response->getStatusCode());
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     /**

--- a/Tests/Unit/Controller/VisionControllerTest.php
+++ b/Tests/Unit/Controller/VisionControllerTest.php
@@ -68,11 +68,16 @@ final class VisionControllerTest extends TestCase
         $request  = $this->createJsonRequest(['imageUrl' => 'https://example.com/cat.jpg']);
         $response = $this->subject->analyzeAction($request);
 
+        self::assertSame(200, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertTrue($data['success']);
         self::assertSame('A cat sitting on a mat', $data['altText']);
         self::assertSame('gpt-4o', $data['model']);
         self::assertSame(0.95, $data['confidence']);
+        self::assertArrayHasKey('usage', $data);
+        self::assertSame(100, $data['usage']['promptTokens']);
+        self::assertSame(50, $data['usage']['completionTokens']);
+        self::assertSame(150, $data['usage']['totalTokens']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
@@ -89,6 +94,7 @@ final class VisionControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+        self::assertStringContainsString('Missing', $data['error']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
@@ -104,6 +110,9 @@ final class VisionControllerTest extends TestCase
         $response = $this->subject->analyzeAction($request);
 
         self::assertSame(429, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+        self::assertArrayHasKey('error', $data);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('0', $response->getHeaderLine('X-RateLimit-Remaining'));
         self::assertNotEmpty($response->getHeaderLine('Retry-After'));
@@ -120,6 +129,7 @@ final class VisionControllerTest extends TestCase
 
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
         self::assertStringContainsString('Invalid JSON', $data['error']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
@@ -137,6 +147,7 @@ final class VisionControllerTest extends TestCase
 
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
         self::assertStringContainsString('maximum length', $data['error']);
     }
 
@@ -155,6 +166,8 @@ final class VisionControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+        self::assertArrayHasKey('error', $data);
+        self::assertStringContainsString('failed', $data['error']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }

--- a/Tests/Unit/Controller/VisionControllerTest.php
+++ b/Tests/Unit/Controller/VisionControllerTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
+
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Service\Feature\VisionService;
+use Netresearch\T3Cowriter\Controller\VisionController;
+use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Context\Context;
+
+#[CoversClass(VisionController::class)]
+final class VisionControllerTest extends TestCase
+{
+    private VisionService&Stub $visionServiceStub;
+    private RateLimiterInterface&Stub $rateLimiterStub;
+    private VisionController $subject;
+
+    protected function setUp(): void
+    {
+        $this->visionServiceStub = $this->createStub(VisionService::class);
+        $this->rateLimiterStub   = $this->createStub(RateLimiterInterface::class);
+        $contextStub             = $this->createStub(Context::class);
+
+        $contextStub->method('getPropertyFromAspect')
+            ->willReturn(1);
+
+        $this->subject = new VisionController(
+            $this->visionServiceStub,
+            $this->rateLimiterStub,
+            $contextStub,
+            new NullLogger(),
+        );
+    }
+
+    #[Test]
+    public function analyzeActionReturnsAltText(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $visionResponse = new VisionResponse(
+            description: 'A cat sitting on a mat',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(100, 50, 150),
+            confidence: 0.95,
+        );
+
+        $this->visionServiceStub->method('analyzeImageFull')
+            ->willReturn($visionResponse);
+
+        $request  = $this->createJsonRequest(['imageUrl' => 'https://example.com/cat.jpg']);
+        $response = $this->subject->analyzeAction($request);
+
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertTrue($data['success']);
+        self::assertSame('A cat sitting on a mat', $data['altText']);
+        self::assertSame('gpt-4o', $data['model']);
+        self::assertSame(0.95, $data['confidence']);
+    }
+
+    #[Test]
+    public function analyzeActionReturns400ForMissingImageUrl(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $request  = $this->createJsonRequest([]);
+        $response = $this->subject->analyzeAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+    }
+
+    #[Test]
+    public function analyzeActionReturns429WhenRateLimited(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(false, 20, 0, time() + 60));
+
+        $request  = $this->createJsonRequest(['imageUrl' => 'https://example.com/image.jpg']);
+        $response = $this->subject->analyzeAction($request);
+
+        self::assertSame(429, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function analyzeActionReturns500OnServiceError(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $this->visionServiceStub->method('analyzeImageFull')
+            ->willThrowException(new RuntimeException('API error'));
+
+        $request  = $this->createJsonRequest(['imageUrl' => 'https://example.com/image.jpg']);
+        $response = $this->subject->analyzeAction($request);
+
+        self::assertSame(500, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+    }
+
+    private function createJsonRequest(array $body): ServerRequestInterface&Stub
+    {
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn($body);
+
+        return $request;
+    }
+}

--- a/Tests/Unit/Controller/VisionControllerTest.php
+++ b/Tests/Unit/Controller/VisionControllerTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use TYPO3\CMS\Core\Context\Context;
@@ -89,15 +90,48 @@ final class VisionControllerTest extends TestCase
     }
 
     #[Test]
-    public function analyzeActionReturns429WhenRateLimited(): void
+    public function analyzeActionReturns429WithHeadersWhenRateLimited(): void
     {
+        $resetTime = time() + 60;
         $this->rateLimiterStub->method('checkLimit')
-            ->willReturn(new RateLimitResult(false, 20, 0, time() + 60));
+            ->willReturn(new RateLimitResult(false, 20, 0, $resetTime));
 
         $request  = $this->createJsonRequest(['imageUrl' => 'https://example.com/image.jpg']);
         $response = $this->subject->analyzeAction($request);
 
         self::assertSame(429, $response->getStatusCode());
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('0', $response->getHeaderLine('X-RateLimit-Remaining'));
+        self::assertNotEmpty($response->getHeaderLine('Retry-After'));
+    }
+
+    #[Test]
+    public function analyzeActionReturns400ForInvalidJson(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $request  = $this->createRawRequest('not valid json{');
+        $response = $this->subject->analyzeAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertStringContainsString('Invalid JSON', $data['error']);
+    }
+
+    #[Test]
+    public function analyzeActionReturns400ForExcessiveFieldLength(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $longUrl  = 'https://example.com/' . str_repeat('a', 40000);
+        $request  = $this->createJsonRequest(['imageUrl' => $longUrl]);
+        $response = $this->subject->analyzeAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertStringContainsString('maximum length', $data['error']);
     }
 
     #[Test]
@@ -117,10 +151,21 @@ final class VisionControllerTest extends TestCase
         self::assertFalse($data['success']);
     }
 
+    /**
+     * @param array<string, mixed> $body
+     */
     private function createJsonRequest(array $body): ServerRequestInterface&Stub
     {
+        return $this->createRawRequest(json_encode($body, JSON_THROW_ON_ERROR));
+    }
+
+    private function createRawRequest(string $rawBody): ServerRequestInterface&Stub
+    {
+        $stream = $this->createStub(StreamInterface::class);
+        $stream->method('__toString')->willReturn($rawBody);
+
         $request = $this->createStub(ServerRequestInterface::class);
-        $request->method('getParsedBody')->willReturn($body);
+        $request->method('getBody')->willReturn($stream);
 
         return $request;
     }

--- a/Tests/Unit/Controller/VisionControllerTest.php
+++ b/Tests/Unit/Controller/VisionControllerTest.php
@@ -73,6 +73,8 @@ final class VisionControllerTest extends TestCase
         self::assertSame('A cat sitting on a mat', $data['altText']);
         self::assertSame('gpt-4o', $data['model']);
         self::assertSame(0.95, $data['confidence']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -87,6 +89,8 @@ final class VisionControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -117,6 +121,8 @@ final class VisionControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertStringContainsString('Invalid JSON', $data['error']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     #[Test]
@@ -149,6 +155,8 @@ final class VisionControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);
         self::assertFalse($data['success']);
+        self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
+        self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
     }
 
     /**

--- a/Tests/Unit/Domain/DTO/CompleteResponseTest.php
+++ b/Tests/Unit/Domain/DTO/CompleteResponseTest.php
@@ -126,6 +126,8 @@ final class CompleteResponseTest extends TestCase
 
         $this->assertFalse($json['success']);
         $this->assertSame('Test error', $json['error']);
+        $this->assertFalse($json['wasTruncated']);
+        $this->assertFalse($json['wasFiltered']);
         $this->assertArrayNotHasKey('content', $json);
         $this->assertArrayNotHasKey('model', $json);
         $this->assertArrayNotHasKey('finishReason', $json);

--- a/Tests/Unit/Domain/DTO/CompleteResponseTest.php
+++ b/Tests/Unit/Domain/DTO/CompleteResponseTest.php
@@ -232,6 +232,84 @@ final class CompleteResponseTest extends TestCase
         $this->assertSame("it's done", $response->finishReason);
     }
 
+    #[Test]
+    public function successDetectsWasTruncated(): void
+    {
+        $usage = new UsageStatistics(10, 20, 30);
+
+        $completionResponse = new CompletionResponse(
+            content: 'Partial text...',
+            model: 'test-model',
+            usage: $usage,
+            finishReason: 'length',
+            provider: 'test',
+        );
+
+        $response = CompleteResponse::success($completionResponse);
+
+        self::assertTrue($response->wasTruncated);
+        self::assertFalse($response->wasFiltered);
+    }
+
+    #[Test]
+    public function successDetectsWasFiltered(): void
+    {
+        $usage = new UsageStatistics(10, 20, 30);
+
+        $completionResponse = new CompletionResponse(
+            content: '',
+            model: 'test-model',
+            usage: $usage,
+            finishReason: 'content_filter',
+            provider: 'test',
+        );
+
+        $response = CompleteResponse::success($completionResponse);
+
+        self::assertFalse($response->wasTruncated);
+        self::assertTrue($response->wasFiltered);
+    }
+
+    #[Test]
+    public function successNormalCompletionNotTruncatedOrFiltered(): void
+    {
+        $completionResponse = $this->createCompletionResponse('Complete text');
+
+        $response = CompleteResponse::success($completionResponse);
+
+        self::assertFalse($response->wasTruncated);
+        self::assertFalse($response->wasFiltered);
+    }
+
+    #[Test]
+    public function jsonSerializeIncludesTruncationAndFilterFlags(): void
+    {
+        $usage = new UsageStatistics(10, 20, 30);
+
+        $completionResponse = new CompletionResponse(
+            content: 'Partial...',
+            model: 'test-model',
+            usage: $usage,
+            finishReason: 'length',
+            provider: 'test',
+        );
+
+        $response = CompleteResponse::success($completionResponse);
+        $json     = $response->jsonSerialize();
+
+        self::assertTrue($json['wasTruncated']);
+        self::assertFalse($json['wasFiltered']);
+    }
+
+    #[Test]
+    public function errorResponseHasFalseTruncationFlags(): void
+    {
+        $response = CompleteResponse::error('Something went wrong');
+
+        self::assertFalse($response->wasTruncated);
+        self::assertFalse($response->wasFiltered);
+    }
+
     private function createCompletionResponse(
         string $content,
         int $promptTokens = 10,

--- a/Tests/Unit/Domain/DTO/ToolRequestTest.php
+++ b/Tests/Unit/Domain/DTO/ToolRequestTest.php
@@ -37,7 +37,6 @@ final class ToolRequestTest extends TestCase
         $request = ToolRequest::fromRequestBody($body);
 
         self::assertSame([], $request->enabledTools);
-        self::assertNull($request->configuration);
     }
 
     #[Test]
@@ -56,15 +55,6 @@ final class ToolRequestTest extends TestCase
         $request = ToolRequest::fromRequestBody($body);
 
         self::assertSame('Find elements', $request->prompt);
-    }
-
-    #[Test]
-    public function fromRequestBodyParsesConfiguration(): void
-    {
-        $body    = ['prompt' => 'Find', 'configuration' => 'claude-fast'];
-        $request = ToolRequest::fromRequestBody($body);
-
-        self::assertSame('claude-fast', $request->configuration);
     }
 
     #[Test]

--- a/Tests/Unit/Domain/DTO/ToolRequestTest.php
+++ b/Tests/Unit/Domain/DTO/ToolRequestTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Unit\Domain\DTO;
+
+use Netresearch\T3Cowriter\Domain\DTO\ToolRequest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ToolRequest::class)]
+final class ToolRequestTest extends TestCase
+{
+    #[Test]
+    public function fromRequestBodyParsesAllFields(): void
+    {
+        $body = [
+            'prompt' => 'Find all text elements',
+            'tools'  => ['query_content'],
+        ];
+        $request = ToolRequest::fromRequestBody($body);
+
+        self::assertSame('Find all text elements', $request->prompt);
+        self::assertSame(['query_content'], $request->enabledTools);
+    }
+
+    #[Test]
+    public function fromRequestBodyUsesDefaults(): void
+    {
+        $body    = ['prompt' => 'Hello'];
+        $request = ToolRequest::fromRequestBody($body);
+
+        self::assertSame([], $request->enabledTools);
+        self::assertNull($request->configuration);
+    }
+
+    #[Test]
+    public function fromRequestBodyHandlesMissingFields(): void
+    {
+        $request = ToolRequest::fromRequestBody([]);
+
+        self::assertSame('', $request->prompt);
+        self::assertSame([], $request->enabledTools);
+    }
+
+    #[Test]
+    public function fromRequestBodyTrimsWhitespace(): void
+    {
+        $body    = ['prompt' => '  Find elements  '];
+        $request = ToolRequest::fromRequestBody($body);
+
+        self::assertSame('Find elements', $request->prompt);
+    }
+
+    #[Test]
+    public function fromRequestBodyParsesConfiguration(): void
+    {
+        $body    = ['prompt' => 'Find', 'configuration' => 'claude-fast'];
+        $request = ToolRequest::fromRequestBody($body);
+
+        self::assertSame('claude-fast', $request->configuration);
+    }
+
+    #[Test]
+    public function fromRequestBodyHandlesNonScalarPrompt(): void
+    {
+        $body    = ['prompt' => ['nested', 'array']];
+        $request = ToolRequest::fromRequestBody($body);
+
+        self::assertSame('', $request->prompt);
+    }
+
+    #[Test]
+    public function fromRequestBodyHandlesNonArrayTools(): void
+    {
+        $body    = ['prompt' => 'Find', 'tools' => 'not-an-array'];
+        $request = ToolRequest::fromRequestBody($body);
+
+        self::assertSame([], $request->enabledTools);
+    }
+
+    #[Test]
+    public function fromRequestBodyFiltersEmptyToolNames(): void
+    {
+        $body    = ['prompt' => 'Find', 'tools' => ['query_content', '', '  ', 'another_tool']];
+        $request = ToolRequest::fromRequestBody($body);
+
+        self::assertSame(['query_content', 'another_tool'], $request->enabledTools);
+    }
+}

--- a/Tests/Unit/Domain/DTO/ToolRequestTest.php
+++ b/Tests/Unit/Domain/DTO/ToolRequestTest.php
@@ -107,4 +107,18 @@ final class ToolRequestTest extends TestCase
         $request = new ToolRequest(prompt: str_repeat('a', 40000));
         self::assertFalse($request->isValid());
     }
+
+    #[Test]
+    public function isValidReturnsTrueAtExactMaxLength(): void
+    {
+        $request = new ToolRequest(prompt: str_repeat('a', 32768));
+        self::assertTrue($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsFalseAtOneOverMaxLength(): void
+    {
+        $request = new ToolRequest(prompt: str_repeat('a', 32769));
+        self::assertFalse($request->isValid());
+    }
 }

--- a/Tests/Unit/Domain/DTO/ToolRequestTest.php
+++ b/Tests/Unit/Domain/DTO/ToolRequestTest.php
@@ -93,4 +93,18 @@ final class ToolRequestTest extends TestCase
 
         self::assertSame(['query_content', 'another_tool'], $request->enabledTools);
     }
+
+    #[Test]
+    public function isValidReturnsTrueForNormalInput(): void
+    {
+        $request = new ToolRequest(prompt: 'Find all text elements');
+        self::assertTrue($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsFalseForExcessivePromptLength(): void
+    {
+        $request = new ToolRequest(prompt: str_repeat('a', 40000));
+        self::assertFalse($request->isValid());
+    }
 }

--- a/Tests/Unit/Domain/DTO/TranslationRequestTest.php
+++ b/Tests/Unit/Domain/DTO/TranslationRequestTest.php
@@ -13,6 +13,7 @@ use Netresearch\T3Cowriter\Domain\DTO\TranslationRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 #[CoversClass(TranslationRequest::class)]
 final class TranslationRequestTest extends TestCase
@@ -71,5 +72,27 @@ final class TranslationRequestTest extends TestCase
         $request = TranslationRequest::fromRequestBody($body);
 
         self::assertSame('claude-fast', $request->configuration);
+    }
+
+    #[Test]
+    public function fromRequestBodyHandlesNonScalarText(): void
+    {
+        $body    = ['text' => ['nested', 'array'], 'targetLanguage' => 'de'];
+        $request = TranslationRequest::fromRequestBody($body);
+
+        // Non-scalar text falls back to default empty string
+        self::assertSame('', $request->text);
+        self::assertSame('de', $request->targetLanguage);
+    }
+
+    #[Test]
+    public function fromRequestBodyHandlesNonScalarTargetLanguage(): void
+    {
+        $body    = ['text' => 'Hello', 'targetLanguage' => new stdClass()];
+        $request = TranslationRequest::fromRequestBody($body);
+
+        // Non-scalar targetLanguage falls back to default empty string
+        self::assertSame('Hello', $request->text);
+        self::assertSame('', $request->targetLanguage);
     }
 }

--- a/Tests/Unit/Domain/DTO/TranslationRequestTest.php
+++ b/Tests/Unit/Domain/DTO/TranslationRequestTest.php
@@ -95,4 +95,25 @@ final class TranslationRequestTest extends TestCase
         self::assertSame('Hello', $request->text);
         self::assertSame('', $request->targetLanguage);
     }
+
+    #[Test]
+    public function isValidReturnsTrueForNormalInput(): void
+    {
+        $request = new TranslationRequest(text: 'Hello world', targetLanguage: 'de');
+        self::assertTrue($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsFalseForExcessiveTextLength(): void
+    {
+        $request = new TranslationRequest(text: str_repeat('a', 40000), targetLanguage: 'de');
+        self::assertFalse($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsFalseForExcessiveTargetLanguageLength(): void
+    {
+        $request = new TranslationRequest(text: 'Hello', targetLanguage: 'a-very-long-language-code');
+        self::assertFalse($request->isValid());
+    }
 }

--- a/Tests/Unit/Domain/DTO/TranslationRequestTest.php
+++ b/Tests/Unit/Domain/DTO/TranslationRequestTest.php
@@ -116,4 +116,26 @@ final class TranslationRequestTest extends TestCase
         $request = new TranslationRequest(text: 'Hello', targetLanguage: 'a-very-long-language-code');
         self::assertFalse($request->isValid());
     }
+
+    #[Test]
+    public function isValidReturnsFalseForExcessiveFormalityLength(): void
+    {
+        $request = new TranslationRequest(
+            text: 'Hello',
+            targetLanguage: 'de',
+            formality: str_repeat('a', 51),
+        );
+        self::assertFalse($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsFalseForExcessiveDomainLength(): void
+    {
+        $request = new TranslationRequest(
+            text: 'Hello',
+            targetLanguage: 'de',
+            domain: str_repeat('a', 101),
+        );
+        self::assertFalse($request->isValid());
+    }
 }

--- a/Tests/Unit/Domain/DTO/TranslationRequestTest.php
+++ b/Tests/Unit/Domain/DTO/TranslationRequestTest.php
@@ -104,6 +104,20 @@ final class TranslationRequestTest extends TestCase
     }
 
     #[Test]
+    public function isValidReturnsTrueAtExactMaxTextLength(): void
+    {
+        $request = new TranslationRequest(text: str_repeat('a', 32768), targetLanguage: 'de');
+        self::assertTrue($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsFalseAtOneOverMaxTextLength(): void
+    {
+        $request = new TranslationRequest(text: str_repeat('a', 32769), targetLanguage: 'de');
+        self::assertFalse($request->isValid());
+    }
+
+    #[Test]
     public function isValidReturnsFalseForExcessiveTextLength(): void
     {
         $request = new TranslationRequest(text: str_repeat('a', 40000), targetLanguage: 'de');
@@ -111,10 +125,28 @@ final class TranslationRequestTest extends TestCase
     }
 
     #[Test]
+    public function isValidReturnsTrueAtExactMaxTargetLanguageLength(): void
+    {
+        $request = new TranslationRequest(text: 'Hello', targetLanguage: str_repeat('a', 10));
+        self::assertTrue($request->isValid());
+    }
+
+    #[Test]
     public function isValidReturnsFalseForExcessiveTargetLanguageLength(): void
     {
-        $request = new TranslationRequest(text: 'Hello', targetLanguage: 'a-very-long-language-code');
+        $request = new TranslationRequest(text: 'Hello', targetLanguage: str_repeat('a', 11));
         self::assertFalse($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsTrueAtExactMaxFormalityLength(): void
+    {
+        $request = new TranslationRequest(
+            text: 'Hello',
+            targetLanguage: 'de',
+            formality: str_repeat('a', 50),
+        );
+        self::assertTrue($request->isValid());
     }
 
     #[Test]
@@ -126,6 +158,17 @@ final class TranslationRequestTest extends TestCase
             formality: str_repeat('a', 51),
         );
         self::assertFalse($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsTrueAtExactMaxDomainLength(): void
+    {
+        $request = new TranslationRequest(
+            text: 'Hello',
+            targetLanguage: 'de',
+            domain: str_repeat('a', 100),
+        );
+        self::assertTrue($request->isValid());
     }
 
     #[Test]

--- a/Tests/Unit/Domain/DTO/TranslationRequestTest.php
+++ b/Tests/Unit/Domain/DTO/TranslationRequestTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Unit\Domain\DTO;
+
+use Netresearch\T3Cowriter\Domain\DTO\TranslationRequest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TranslationRequest::class)]
+final class TranslationRequestTest extends TestCase
+{
+    #[Test]
+    public function fromRequestBodyParsesAllFields(): void
+    {
+        $body = [
+            'text'           => 'Hello world',
+            'targetLanguage' => 'de',
+            'formality'      => 'formal',
+            'domain'         => 'technical',
+        ];
+        $request = TranslationRequest::fromRequestBody($body);
+
+        self::assertSame('Hello world', $request->text);
+        self::assertSame('de', $request->targetLanguage);
+        self::assertSame('formal', $request->formality);
+        self::assertSame('technical', $request->domain);
+    }
+
+    #[Test]
+    public function fromRequestBodyUsesDefaults(): void
+    {
+        $body    = ['text' => 'Hello', 'targetLanguage' => 'fr'];
+        $request = TranslationRequest::fromRequestBody($body);
+
+        self::assertSame('default', $request->formality);
+        self::assertSame('general', $request->domain);
+        self::assertNull($request->configuration);
+    }
+
+    #[Test]
+    public function fromRequestBodyHandlesMissingFields(): void
+    {
+        $request = TranslationRequest::fromRequestBody([]);
+
+        self::assertSame('', $request->text);
+        self::assertSame('', $request->targetLanguage);
+    }
+
+    #[Test]
+    public function fromRequestBodyTrimsWhitespace(): void
+    {
+        $body    = ['text' => '  Hello  ', 'targetLanguage' => ' de '];
+        $request = TranslationRequest::fromRequestBody($body);
+
+        self::assertSame('Hello', $request->text);
+        self::assertSame('de', $request->targetLanguage);
+    }
+
+    #[Test]
+    public function fromRequestBodyParsesConfiguration(): void
+    {
+        $body    = ['text' => 'Hello', 'targetLanguage' => 'de', 'configuration' => 'claude-fast'];
+        $request = TranslationRequest::fromRequestBody($body);
+
+        self::assertSame('claude-fast', $request->configuration);
+    }
+}

--- a/Tests/Unit/Domain/DTO/VisionRequestTest.php
+++ b/Tests/Unit/Domain/DTO/VisionRequestTest.php
@@ -94,9 +94,37 @@ final class VisionRequestTest extends TestCase
     }
 
     #[Test]
+    public function isValidReturnsTrueAtExactMaxImageUrlLength(): void
+    {
+        $request = new VisionRequest(imageUrl: str_repeat('a', 32768));
+        self::assertTrue($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsFalseAtOneOverMaxImageUrlLength(): void
+    {
+        $request = new VisionRequest(imageUrl: str_repeat('a', 32769));
+        self::assertFalse($request->isValid());
+    }
+
+    #[Test]
     public function isValidReturnsFalseForExcessiveImageUrlLength(): void
     {
         $request = new VisionRequest(imageUrl: str_repeat('a', 40000));
+        self::assertFalse($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsTrueAtExactMaxPromptLength(): void
+    {
+        $request = new VisionRequest(imageUrl: 'https://example.com/img.jpg', prompt: str_repeat('a', 32768));
+        self::assertTrue($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsFalseAtOneOverMaxPromptLength(): void
+    {
+        $request = new VisionRequest(imageUrl: 'https://example.com/img.jpg', prompt: str_repeat('a', 32769));
         self::assertFalse($request->isValid());
     }
 

--- a/Tests/Unit/Domain/DTO/VisionRequestTest.php
+++ b/Tests/Unit/Domain/DTO/VisionRequestTest.php
@@ -37,15 +37,6 @@ final class VisionRequestTest extends TestCase
     }
 
     #[Test]
-    public function fromRequestBodyParsesConfiguration(): void
-    {
-        $body    = ['imageUrl' => 'https://example.com/image.jpg', 'configuration' => 'openai-gpt4'];
-        $request = VisionRequest::fromRequestBody($body);
-
-        self::assertSame('openai-gpt4', $request->configuration);
-    }
-
-    #[Test]
     public function fromRequestBodyTrimsWhitespace(): void
     {
         $body    = ['imageUrl' => '  https://example.com/image.jpg  ', 'prompt' => '  test  '];
@@ -61,7 +52,6 @@ final class VisionRequestTest extends TestCase
         $request = VisionRequest::fromRequestBody([]);
 
         self::assertSame('', $request->imageUrl);
-        self::assertNull($request->configuration);
     }
 
     #[Test]

--- a/Tests/Unit/Domain/DTO/VisionRequestTest.php
+++ b/Tests/Unit/Domain/DTO/VisionRequestTest.php
@@ -63,4 +63,26 @@ final class VisionRequestTest extends TestCase
         self::assertSame('', $request->imageUrl);
         self::assertNull($request->configuration);
     }
+
+    #[Test]
+    public function fromRequestBodyHandlesNonScalarImageUrl(): void
+    {
+        $body    = ['imageUrl' => ['nested', 'array'], 'prompt' => 'Generate alt text'];
+        $request = VisionRequest::fromRequestBody($body);
+
+        // Non-scalar values fall back to default empty string
+        self::assertSame('', $request->imageUrl);
+        self::assertSame('Generate alt text', $request->prompt);
+    }
+
+    #[Test]
+    public function fromRequestBodyHandlesNonScalarPrompt(): void
+    {
+        $body    = ['imageUrl' => 'https://example.com/image.jpg', 'prompt' => ['array', 'value']];
+        $request = VisionRequest::fromRequestBody($body);
+
+        // Non-scalar prompt falls back to default prompt
+        self::assertSame('https://example.com/image.jpg', $request->imageUrl);
+        self::assertSame('Generate a concise, descriptive alt text for this image.', $request->prompt);
+    }
 }

--- a/Tests/Unit/Domain/DTO/VisionRequestTest.php
+++ b/Tests/Unit/Domain/DTO/VisionRequestTest.php
@@ -85,4 +85,25 @@ final class VisionRequestTest extends TestCase
         self::assertSame('https://example.com/image.jpg', $request->imageUrl);
         self::assertSame('Generate a concise, descriptive alt text for this image.', $request->prompt);
     }
+
+    #[Test]
+    public function isValidReturnsTrueForNormalInput(): void
+    {
+        $request = new VisionRequest(imageUrl: 'https://example.com/img.jpg', prompt: 'Describe this image');
+        self::assertTrue($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsFalseForExcessiveImageUrlLength(): void
+    {
+        $request = new VisionRequest(imageUrl: str_repeat('a', 40000));
+        self::assertFalse($request->isValid());
+    }
+
+    #[Test]
+    public function isValidReturnsFalseForExcessivePromptLength(): void
+    {
+        $request = new VisionRequest(imageUrl: 'https://example.com/img.jpg', prompt: str_repeat('a', 40000));
+        self::assertFalse($request->isValid());
+    }
 }

--- a/Tests/Unit/Domain/DTO/VisionRequestTest.php
+++ b/Tests/Unit/Domain/DTO/VisionRequestTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Unit\Domain\DTO;
+
+use Netresearch\T3Cowriter\Domain\DTO\VisionRequest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(VisionRequest::class)]
+final class VisionRequestTest extends TestCase
+{
+    #[Test]
+    public function fromRequestBodyParsesImageUrl(): void
+    {
+        $body    = ['imageUrl' => 'https://example.com/image.jpg', 'prompt' => 'Generate alt text'];
+        $request = VisionRequest::fromRequestBody($body);
+
+        self::assertSame('https://example.com/image.jpg', $request->imageUrl);
+        self::assertSame('Generate alt text', $request->prompt);
+    }
+
+    #[Test]
+    public function fromRequestBodyUsesDefaultPrompt(): void
+    {
+        $body    = ['imageUrl' => 'https://example.com/image.jpg'];
+        $request = VisionRequest::fromRequestBody($body);
+
+        self::assertSame('Generate a concise, descriptive alt text for this image.', $request->prompt);
+    }
+
+    #[Test]
+    public function fromRequestBodyParsesConfiguration(): void
+    {
+        $body    = ['imageUrl' => 'https://example.com/image.jpg', 'configuration' => 'openai-gpt4'];
+        $request = VisionRequest::fromRequestBody($body);
+
+        self::assertSame('openai-gpt4', $request->configuration);
+    }
+
+    #[Test]
+    public function fromRequestBodyTrimsWhitespace(): void
+    {
+        $body    = ['imageUrl' => '  https://example.com/image.jpg  ', 'prompt' => '  test  '];
+        $request = VisionRequest::fromRequestBody($body);
+
+        self::assertSame('https://example.com/image.jpg', $request->imageUrl);
+        self::assertSame('test', $request->prompt);
+    }
+
+    #[Test]
+    public function fromRequestBodyHandlesMissingImageUrl(): void
+    {
+        $request = VisionRequest::fromRequestBody([]);
+
+        self::assertSame('', $request->imageUrl);
+        self::assertNull($request->configuration);
+    }
+}

--- a/Tests/Unit/Service/ContextAssemblyServiceTest.php
+++ b/Tests/Unit/Service/ContextAssemblyServiceTest.php
@@ -273,6 +273,74 @@ final class ContextAssemblyServiceTest extends TestCase
     }
 
     #[Test]
+    public function formatSingleRecordUsesUcfirstLabels(): void
+    {
+        $connectionPool = $this->createConnectionPoolMock([
+            ['uid' => 1, 'pid' => 5, 'header' => 'My Header', 'subheader' => 'My Sub', 'bodytext' => '<p>Content</p>'],
+        ]);
+
+        $service = new ContextAssemblyService($connectionPool);
+        $result  = $service->assembleContext('tt_content', 1, 'bodytext', 'element');
+
+        self::assertStringContainsString('Header: My Header', $result);
+        self::assertStringContainsString('Subheader: My Sub', $result);
+        self::assertStringContainsString('Bodytext: <p>Content</p>', $result);
+    }
+
+    #[Test]
+    public function formatRecordsMarksCurrentElement(): void
+    {
+        $connectionPool = $this->createConnectionPoolMock([
+            ['uid' => 10, 'pid' => 5, 'header' => 'First', 'subheader' => '', 'bodytext' => 'A'],
+            ['uid' => 20, 'pid' => 5, 'header' => 'Second', 'subheader' => '', 'bodytext' => 'B'],
+        ]);
+
+        $service = new ContextAssemblyService($connectionPool);
+        $result  = $service->assembleContext('tt_content', 10, 'bodytext', 'page');
+
+        self::assertStringContainsString('=== Current content element (tt_content #10) ===', $result);
+        self::assertStringContainsString('--- Content element (tt_content #20) ---', $result);
+    }
+
+    #[Test]
+    public function countWordsHandlesHtmlEntities(): void
+    {
+        $service = new ContextAssemblyService($this->createConnectionPoolMock([]));
+        $method  = new ReflectionMethod($service, 'countWords');
+
+        self::assertSame(5, $method->invoke($service, 'one &amp; two &lt; three'));
+    }
+
+    #[Test]
+    public function countWordsReturnsZeroForEmptyString(): void
+    {
+        $service = new ContextAssemblyService($this->createConnectionPoolMock([]));
+        $method  = new ReflectionMethod($service, 'countWords');
+
+        self::assertSame(0, $method->invoke($service, ''));
+    }
+
+    #[Test]
+    public function assembleContextWithEmptyRelationOmitsRelationPrefix(): void
+    {
+        $connectionPool = $this->createConnectionPoolMock([
+            ['uid' => 123, 'pid' => 5, 'header' => 'Main', 'bodytext' => '<p>Content</p>', 'subheader' => ''],
+        ]);
+
+        $service = new ContextAssemblyService($connectionPool);
+        $result  = $service->assembleContext(
+            'tt_content',
+            123,
+            'bodytext',
+            'element',
+            [['pid' => 10, 'relation' => '']],
+        );
+
+        self::assertStringContainsString('Reference page (pid=10)', $result);
+        self::assertStringNotContainsString('Relation:', $result);
+    }
+
+    #[Test]
     public function assembleContextIncludesRelationPrefixForReferencePages(): void
     {
         // Kills Concat #114, ConcatOperandRemoval #115 on reference page relation

--- a/Tests/Unit/Tools/ContentQueryToolTest.php
+++ b/Tests/Unit/Tools/ContentQueryToolTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Tests\Unit\Tools;
+
+use Netresearch\T3Cowriter\Tools\ContentQueryTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContentQueryTool::class)]
+final class ContentQueryToolTest extends TestCase
+{
+    #[Test]
+    public function definitionReturnsValidToolSchema(): void
+    {
+        $definition = ContentQueryTool::definition();
+
+        self::assertSame('function', $definition['type']);
+        self::assertSame('query_content', $definition['function']['name']);
+        self::assertArrayHasKey('parameters', $definition['function']);
+    }
+
+    #[Test]
+    public function definitionRequiresPageId(): void
+    {
+        $definition = ContentQueryTool::definition();
+        $required   = $definition['function']['parameters']['required'];
+
+        self::assertContains('pageId', $required);
+    }
+
+    #[Test]
+    public function definitionIncludesContentTypeProperty(): void
+    {
+        $definition = ContentQueryTool::definition();
+        $properties = $definition['function']['parameters']['properties'];
+
+        self::assertArrayHasKey('contentType', $properties);
+        self::assertSame('string', $properties['contentType']['type']);
+    }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -36,8 +36,31 @@ flags:
       - Resources/Public/JavaScript/
     carryforward: true
 
+component_management:
+  individual_components:
+    - component_id: controllers
+      name: Controllers
+      paths:
+        - Classes/Controller/**
+    - component_id: dtos
+      name: Domain DTOs
+      paths:
+        - Classes/Domain/DTO/**
+    - component_id: services
+      name: Services
+      paths:
+        - Classes/Service/**
+    - component_id: tools
+      name: Tools
+      paths:
+        - Classes/Tools/**
+    - component_id: ckeditor
+      name: CKEditor Frontend
+      paths:
+        - Resources/Public/JavaScript/Ckeditor/**
+
 comment:
-  layout: "reach,diff,flags,files"
+  layout: "reach,diff,flags,components,files"
   behavior: default
   require_changes: true
   require_base: false


### PR DESCRIPTION
## Summary

Full nr-llm integration for v2.0.0 modernization: adds 5 new controllers, 4 CKEditor toolbar items, enhanced response metadata, and comprehensive test coverage.

### New Features
- **VisionController** — image analysis and alt text generation via nr-llm VisionService
- **TranslationController** — content translation with formality/domain options via nr-llm TranslationService
- **TemplateController** — prompt template listing via nr-llm PromptTemplateRepository
- **ToolController** — LLM function calling with ContentQueryTool for TYPO3 content queries
- **CKEditor toolbar items** — `cowriterVision`, `cowriterTranslate` (10 languages), `cowriterTemplates` dropdown
- **CompleteResponse** enhanced with `wasTruncated`/`wasFiltered` from nr-llm CompletionResponse

### Infrastructure
- 11 AJAX routes registered with URL injection + CSP-compliant UrlLoader
- All controllers follow readonly pattern with rate limiting, logging, and PHPStan L10 compliance
- Request DTOs with `is_scalar()` guards for mixed input safety

### Test Coverage
- **435 unit tests** (1126 assertions) — all controllers, DTOs, tools
- **27 integration tests** (134 assertions) — full request/response flows
- **66 E2E tests** (298 assertions) — complete user workflows
- **135 JavaScript tests** — AIService, UrlLoader, CowriterDialog, cowriter plugin

### Documentation
- README updated with new features, architecture diagram, toolbar configuration
- AGENTS.md updated with all 11 routes, 5 controllers, full component tree

## Commits (5)
1. `feat: add vision, translation, and template controllers` — Phase 2.1-2.4
2. `test: add comprehensive E2E, integration, and JS tests` — coverage
3. `feat: add tool calling controller and enhance completion response` — Phase 2.3 + 2.5
4. `feat: add vision, translation, and template toolbar items to CKEditor` — Phase 2.6
5. `docs: update README and AGENTS.md for new features and architecture` — Phase 5

## Verification

All checks pass locally:
- PHPStan Level 10: 0 errors (24 files)
- PHP-CS-Fixer: 0 violations (55 files)  
- PHP Unit: 435 tests, 1126 assertions
- PHP Integration: 27 tests, 134 assertions
- PHP E2E: 66 tests, 298 assertions
- JavaScript: 135 tests (4 test files)

## Test Plan

- [ ] CI passes on all PHP 8.2-8.5 x TYPO3 v13.4/v14 matrix combinations
- [ ] Vision endpoint returns alt text for valid image URL
- [ ] Translation endpoint translates text with formality/domain options
- [ ] Templates endpoint returns active prompt templates
- [ ] Tool calling endpoint processes LLM function calls
- [ ] CKEditor toolbar shows all 4 items (cowriter, vision, translate, templates)
- [ ] Rate limiting works for all new endpoints