### PR TITLE
docs: use interlink references for nr-llm documentation

### DIFF
--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -9,9 +9,9 @@ Configuration
 LLM provider setup
 ==================
 
-The Cowriter extension uses the :composer:`netresearch/nr-llm` extension for
-LLM provider configuration. Configure your preferred provider in the nr-llm
-extension settings.
+The Cowriter extension uses the :ref:`nr-llm extension <nrllm:start>` for
+LLM provider configuration. Configure your preferred provider in the
+:ref:`nr-llm backend module <nrllm:configuration-backend-module>`.
 
 Supported providers
 -------------------
@@ -33,7 +33,8 @@ Configuration steps
 
 ..  tip::
 
-    See the `nr-llm documentation <https://github.com/netresearch/t3x-nr-llm>`_
+    See the
+    :ref:`nr-llm provider configuration <nrllm:configuration-provider>`
     for detailed provider configuration options.
 
 RTE configuration
@@ -98,9 +99,10 @@ The four toolbar items are:
 Task configuration
 ==================
 
-The Cowriter dialog shows tasks from the nr-llm extension with
-``category = 'content'``. Default tasks (Improve, Summarize, Extend,
-Fix Grammar, Translate EN/DE) are seeded during installation.
+The Cowriter dialog shows :ref:`tasks <nrllm:configuration-tasks>` from
+the nr-llm extension with ``category = 'content'``. Default tasks
+(Improve, Summarize, Extend, Fix Grammar, Translate EN/DE) are seeded
+during installation.
 
 Adding custom tasks
 -------------------

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -59,7 +59,8 @@ your content directly in the CKEditor rich text editor.
 
     ..  card:: :ref:`Configuration <configuration>`
 
-        Configure the LLM provider via nr-llm and RTE integration.
+        Configure the LLM provider via
+        :ref:`nr-llm <nrllm:start>` and RTE integration.
 
     ..  card:: :ref:`Usage <usage>`
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -10,14 +10,14 @@ The extension is installed via Composer only.
 
 ..  note::
 
-    This extension requires the :composer:`netresearch/nr-llm` extension
+    This extension requires the :ref:`nr-llm extension <nrllm:start>`
     for LLM provider abstraction.
 
 Composer installation
 =====================
 
-Install via Composer (the :composer:`netresearch/nr-llm` dependency is installed
-automatically):
+Install via Composer (the :ref:`nr-llm <nrllm:start>` dependency
+is installed automatically):
 
 ..  code-block:: bash
 
@@ -47,10 +47,10 @@ Migration to 3.x
 Version 3.0.0 introduces significant architectural changes:
 
 1.  **Install nr-llm extension**: The LLM provider abstraction is now handled
-    by the separate :composer:`netresearch/nr-llm` extension.
+    by the separate :ref:`nr-llm extension <nrllm:start>`.
 
 2.  **Configure providers in nr-llm**: API keys and provider settings are
-    now managed through the nr-llm extension configuration.
+    now managed through the :ref:`nr-llm configuration <nrllm:configuration>`.
 
 3.  **Remove old configuration**: The old ``apiKey`` and ``model`` settings
     in the t3_cowriter extension are no longer used.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -11,8 +11,9 @@ What does it do?
 
 The AI Cowriter extension integrates multiple LLM providers directly into the
 TYPO3 CKEditor, allowing editors to generate content with the help of artificial
-intelligence. Using the nr-llm extension, it supports OpenAI, Anthropic Claude,
-Google Gemini, OpenRouter, Mistral, and Groq.
+intelligence. Using the
+:ref:`nr-llm extension <nrllm:start>`, it supports OpenAI,
+Anthropic Claude, Google Gemini, OpenRouter, Mistral, and Groq.
 
 Did you ever wish to have a second person to work on a TYPO3 page together with
 you? This extension allows you to do exactly that. With the help of AI you can
@@ -39,7 +40,8 @@ Features
 *   **CKEditor Integration**: Four toolbar buttons for writing, translation,
     vision, and templates
 *   **Multi-Provider Support**: Works with all LLM providers supported by
-    nr-llm (OpenAI, Claude, Gemini, OpenRouter, Mistral, Groq)
+    :ref:`nr-llm <nrllm:start>` (OpenAI, Claude, Gemini,
+    OpenRouter, Mistral, Groq)
 *   **Secure Backend Proxy**: API keys never exposed to frontend — all
     requests proxied through TYPO3 backend
 *   **Context control**: Choose between selected text or full content element
@@ -55,5 +57,5 @@ Requirements
 
 *   TYPO3 v13.4 or v14
 *   PHP 8.2 or higher
-*   netresearch/nr-llm extension (for LLM provider configuration)
+*   :ref:`nr-llm extension <nrllm:start>` (for LLM provider configuration)
 *   CKEditor (rte_ckeditor) extension

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -79,8 +79,9 @@ The Cowriter dialog lets you choose what to do with your content:
 Available tasks
 ===============
 
-Tasks are configured in the nr-llm extension (``tx_nrllm_task`` table)
-with ``category = 'content'``. The following default tasks are provided:
+:ref:`Tasks <nrllm:configuration-tasks>` are configured in the
+nr-llm extension (``tx_nrllm_task`` table) with
+``category = 'content'``. The following default tasks are provided:
 
 .. list-table::
    :header-rows: 1
@@ -124,10 +125,12 @@ Supported languages:
 *   German, English, French, Spanish, Italian
 *   Dutch, Portuguese, Polish, Japanese, Chinese
 
-The translation uses the default LLM configuration from the nr-llm
-extension. Administrators can optionally pass a ``configuration``
-parameter via the API to route translations through a specific LLM
-provider (e.g. DeepL or a dedicated translation model).
+The translation uses the default
+:ref:`LLM configuration <nrllm:configuration-llm>` from the
+nr-llm extension. Administrators can optionally pass a
+``configuration`` parameter via the API to route translations
+through a specific LLM provider (e.g. DeepL or a dedicated
+translation model).
 
 ..  note::
 

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -27,4 +27,5 @@
     />
 
     <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
+    <inventory id="nrllm" url="https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/"/>
 </guides>


### PR DESCRIPTION
## Summary

- Add nr-llm inventory (`objects.inv`) to `guides.xml` for cross-documentation linking
- Replace hardcoded GitHub links and `:composer:` roles with `:ref:` interlink references (`nrllm:*`) that link to the relevant nr-llm documentation pages on docs.typo3.org
- Affected pages: Index, Introduction, Installation, Configuration, Usage

## Test plan

- [ ] Verify `https://docs.typo3.org/p/netresearch/nr-llm/main/en-us/objects.inv` returns 200
- [ ] After deployment, interlinks resolve to correct nr-llm documentation pages
- [ ] Local render shows only expected "inventory not found" warnings (expected — local renderer doesn't fetch remote inventories)