### PR TITLE
chore: clean up require-dev (remove redundant phpunit)

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -44,6 +44,8 @@ Usage: $(basename "$0") [OPTIONS] <COMMAND>
 Commands:
     unit              Run unit tests
     functional        Run functional tests
+    integration       Run integration tests
+    e2e               Run end-to-end tests
     mutation          Run mutation tests with Infection
     phpstan           Run PHPStan static analysis
     cgl               Run PHP-CS-Fixer in dry-run mode
@@ -139,6 +141,36 @@ run_functional_tests() {
 }
 
 #
+# Run integration tests
+#
+run_integration_tests() {
+    info "Running integration tests..."
+    check_dependencies
+
+    if [[ -f "${ROOT_DIR}/Build/phpunit/IntegrationTests.xml" ]]; then
+        "${VENDOR_BIN}/phpunit" -c "${ROOT_DIR}/Build/phpunit/IntegrationTests.xml" ${EXTRA_TEST_OPTIONS}
+    else
+        warning "IntegrationTests.xml not found, skipping..."
+    fi
+    success "Integration tests completed"
+}
+
+#
+# Run end-to-end tests
+#
+run_e2e_tests() {
+    info "Running end-to-end tests..."
+    check_dependencies
+
+    if [[ -f "${ROOT_DIR}/Build/phpunit/E2ETests.xml" ]]; then
+        "${VENDOR_BIN}/phpunit" -c "${ROOT_DIR}/Build/phpunit/E2ETests.xml" ${EXTRA_TEST_OPTIONS}
+    else
+        warning "E2ETests.xml not found, skipping..."
+    fi
+    success "E2E tests completed"
+}
+
+#
 # Run mutation tests
 #
 run_mutation_tests() {
@@ -225,6 +257,8 @@ run_all() {
     run_rector
     run_unit_tests
     run_functional_tests
+    run_integration_tests
+    run_e2e_tests
     success "All tests and checks completed"
 }
 
@@ -264,6 +298,14 @@ parse_args() {
                 ;;
             functional)
                 run_functional_tests
+                exit 0
+                ;;
+            integration)
+                run_integration_tests
+                exit 0
+                ;;
+            e2e)
+                run_e2e_tests
                 exit 0
                 ;;
             mutation)

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -9,3 +9,5 @@ parameters:
 
     excludePaths:
         - %currentWorkingDirectory%/ext_localconf.php
+
+    reportUnmatchedIgnoredErrors: false

--- a/composer.json
+++ b/composer.json
@@ -58,8 +58,7 @@
         "netresearch/nr-llm": "^0.3 || ^0.4 || ^0.5"
     },
     "require-dev": {
-        "netresearch/typo3-ci-workflows": "^1.1",
-        "phpunit/phpunit": "^11.2.5 || ^12.1.2"
+        "netresearch/typo3-ci-workflows": "^1.1"
     },
     "autoload": {
         "psr-4": {
@@ -103,48 +102,28 @@
         }
     },
     "scripts": {
-        "ci:cgl": [
-            "php-cs-fixer fix --config Build/.php-cs-fixer.dist.php --diff --verbose --cache-file .Build/.php-cs-fixer.cache"
-        ],
-        "ci:rector": [
-            "rector process --config Build/rector.php"
-        ],
-        "ci:security": [
-            "composer audit"
-        ],
-        "ci:test:php:cgl": [
-            "@ci:cgl --dry-run"
-        ],
+        "ci:cgl": "Build/Scripts/runTests.sh cgl:fix",
+        "ci:rector": "Build/Scripts/runTests.sh rector:fix",
+        "ci:security": "composer audit",
+        "ci:test:php:cgl": "Build/Scripts/runTests.sh cgl",
         "ci:test:php:lint": [
             "phplint --configuration Build/.phplint.yml"
         ],
-        "ci:test:php:phpstan": [
-            "phpstan analyze --configuration Build/phpstan.neon --memory-limit=-1"
-        ],
+        "ci:test:php:phpstan": "Build/Scripts/runTests.sh phpstan",
         "ci:test:php:phpstan:baseline": [
             "phpstan analyze --configuration Build/phpstan.neon --memory-limit=-1 --generate-baseline Build/phpstan-baseline.neon --allow-empty-baseline"
         ],
-        "ci:test:php:rector": [
-            "@ci:rector --dry-run"
-        ],
+        "ci:test:php:rector": "Build/Scripts/runTests.sh rector",
         "ci:test": [
             "@ci:test:php:lint",
             "@ci:test:php:phpstan",
             "@ci:test:php:rector",
             "@ci:test:php:cgl"
         ],
-        "ci:test:php:unit": [
-            "phpunit -c Build/phpunit/UnitTests.xml"
-        ],
-        "ci:test:php:integration": [
-            "phpunit -c Build/phpunit/IntegrationTests.xml"
-        ],
-        "ci:test:php:e2e": [
-            "phpunit -c Build/phpunit/E2ETests.xml"
-        ],
-        "ci:test:php:functional": [
-            "phpunit -c Build/phpunit/FunctionalTests.xml"
-        ],
+        "ci:test:php:unit": "Build/Scripts/runTests.sh unit",
+        "ci:test:php:integration": "Build/Scripts/runTests.sh integration",
+        "ci:test:php:e2e": "Build/Scripts/runTests.sh e2e",
+        "ci:test:php:functional": "Build/Scripts/runTests.sh functional",
         "ci:test:all": [
             "@ci:test:php:unit",
             "@ci:test:php:functional",


### PR DESCRIPTION
## Summary

- Remove `phpunit/phpunit` from `require-dev` — already provided transitively by `netresearch/typo3-ci-workflows`
- Update all `composer scripts` to delegate to `Build/Scripts/runTests.sh` instead of invoking binaries inline (aligns with the pattern used in `nr-passkeys-fe`)
- Add `integration` and `e2e` commands to `runTests.sh` (previously only `unit` and `functional` were supported)
- Add `reportUnmatchedIgnoredErrors: false` to `Build/phpstan.neon`

## Test plan

- [ ] CI passes (no phpunit version conflict, PHPStan clean)
- [ ] `composer ci:test:php:unit` delegates to `runTests.sh unit`
- [ ] `composer ci:test:php:phpstan` delegates to `runTests.sh phpstan`