### PR TITLE
fix(controllers): depend on nr-llm service interfaces, type messages/tools as lists

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -837,7 +837,7 @@ final readonly class AjaxController
      *
      * @param array<mixed> $rawMessages
      *
-     * @return array<int, array{role: string, content: string}>|null Validated messages or null on failure
+     * @return list<array{role: string, content: string}>|null Validated messages or null on failure
      */
     private function validateMessages(array $rawMessages): ?array
     {

--- a/Classes/Controller/ToolController.php
+++ b/Classes/Controller/ToolController.php
@@ -118,7 +118,7 @@ final readonly class ToolController
      *
      * @param list<string> $enabledTools
      *
-     * @return array<int, array{type: string, function: array{name: string, description: string, parameters: array<string, mixed>}}>
+     * @return list<array{type: string, function: array{name: string, description: string, parameters: array<string, mixed>}}>
      */
     private function resolveTools(array $enabledTools): array
     {

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\T3Cowriter\Controller;
 
 use JsonException;
-use Netresearch\NrLlm\Service\Feature\TranslationService;
+use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
 use Netresearch\T3Cowriter\Domain\DTO\TranslationRequest;
 use Netresearch\T3Cowriter\Service\DiagnosticService;
@@ -33,7 +33,7 @@ use TYPO3\CMS\Core\Http\JsonResponse;
 final readonly class TranslationController
 {
     public function __construct(
-        private TranslationService $translationService,
+        private TranslationServiceInterface $translationService,
         private RateLimiterInterface $rateLimiter,
         private Context $context,
         private LoggerInterface $logger,

--- a/Classes/Controller/VisionController.php
+++ b/Classes/Controller/VisionController.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\T3Cowriter\Controller;
 
 use JsonException;
-use Netresearch\NrLlm\Service\Feature\VisionService;
+use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\T3Cowriter\Domain\DTO\VisionRequest;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
@@ -30,7 +30,7 @@ use TYPO3\CMS\Core\Http\JsonResponse;
 final readonly class VisionController
 {
     public function __construct(
-        private VisionService $visionService,
+        private VisionServiceInterface $visionService,
         private RateLimiterInterface $rateLimiter,
         private Context $context,
         private LoggerInterface $logger,

--- a/Tests/E2E/NewFeatureWorkflowTest.php
+++ b/Tests/E2E/NewFeatureWorkflowTest.php
@@ -14,8 +14,8 @@ use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\Repository\PromptTemplateRepository;
-use Netresearch\NrLlm\Service\Feature\TranslationService;
-use Netresearch\NrLlm\Service\Feature\VisionService;
+use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
+use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
 use Netresearch\T3Cowriter\Controller\TemplateController;
 use Netresearch\T3Cowriter\Controller\TranslationController;
 use Netresearch\T3Cowriter\Controller\VisionController;
@@ -53,11 +53,11 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
     /**
      * Create a VisionController with mocked dependencies.
      *
-     * @return array{controller: VisionController, visionService: VisionService&MockObject, rateLimiter: RateLimiterInterface&MockObject, context: Context&MockObject}
+     * @return array{controller: VisionController, visionService: VisionServiceInterface&MockObject, rateLimiter: RateLimiterInterface&MockObject, context: Context&MockObject}
      */
     private function createVisionStack(): array
     {
-        $visionService = $this->createMock(VisionService::class);
+        $visionService = $this->createMock(VisionServiceInterface::class);
         $rateLimiter   = $this->createMock(RateLimiterInterface::class);
         $context       = $this->createMock(Context::class);
 
@@ -91,11 +91,11 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
     /**
      * Create a TranslationController with mocked dependencies.
      *
-     * @return array{controller: TranslationController, translationService: TranslationService&MockObject, rateLimiter: RateLimiterInterface&MockObject, context: Context&MockObject}
+     * @return array{controller: TranslationController, translationService: TranslationServiceInterface&MockObject, rateLimiter: RateLimiterInterface&MockObject, context: Context&MockObject}
      */
     private function createTranslationStack(): array
     {
-        $translationService = $this->createMock(TranslationService::class);
+        $translationService = $this->createMock(TranslationServiceInterface::class);
         $rateLimiter        = $this->createMock(RateLimiterInterface::class);
         $context            = $this->createMock(Context::class);
 

--- a/Tests/Integration/Controller/TranslationControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/TranslationControllerIntegrationTest.php
@@ -11,7 +11,7 @@ namespace Netresearch\T3Cowriter\Tests\Integration\Controller;
 
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
-use Netresearch\NrLlm\Service\Feature\TranslationService;
+use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\T3Cowriter\Controller\TranslationController;
 use Netresearch\T3Cowriter\Service\DiagnosticService;
 use Netresearch\T3Cowriter\Service\Dto\DiagnosticResult;
@@ -38,7 +38,7 @@ use TYPO3\CMS\Core\Context\Context;
 final class TranslationControllerIntegrationTest extends AbstractIntegrationTestCase
 {
     private TranslationController $subject;
-    private TranslationService&MockObject $translationServiceMock;
+    private TranslationServiceInterface&MockObject $translationServiceMock;
     private RateLimiterInterface&MockObject $rateLimiterMock;
     private Context&MockObject $contextMock;
 
@@ -47,7 +47,7 @@ final class TranslationControllerIntegrationTest extends AbstractIntegrationTest
     {
         parent::setUp();
 
-        $this->translationServiceMock = $this->createMock(TranslationService::class);
+        $this->translationServiceMock = $this->createMock(TranslationServiceInterface::class);
         $this->rateLimiterMock        = $this->createMock(RateLimiterInterface::class);
         $this->contextMock            = $this->createMock(Context::class);
 

--- a/Tests/Integration/Controller/VisionControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/VisionControllerIntegrationTest.php
@@ -11,7 +11,7 @@ namespace Netresearch\T3Cowriter\Tests\Integration\Controller;
 
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
-use Netresearch\NrLlm\Service\Feature\VisionService;
+use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
 use Netresearch\T3Cowriter\Controller\VisionController;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
 use Netresearch\T3Cowriter\Service\RateLimitResult;
@@ -35,7 +35,7 @@ use TYPO3\CMS\Core\Context\Context;
 final class VisionControllerIntegrationTest extends AbstractIntegrationTestCase
 {
     private VisionController $subject;
-    private VisionService&MockObject $visionServiceMock;
+    private VisionServiceInterface&MockObject $visionServiceMock;
     private RateLimiterInterface&MockObject $rateLimiterMock;
     private Context&MockObject $contextMock;
 
@@ -44,7 +44,7 @@ final class VisionControllerIntegrationTest extends AbstractIntegrationTestCase
     {
         parent::setUp();
 
-        $this->visionServiceMock = $this->createMock(VisionService::class);
+        $this->visionServiceMock = $this->createMock(VisionServiceInterface::class);
         $this->rateLimiterMock   = $this->createMock(RateLimiterInterface::class);
         $this->contextMock       = $this->createMock(Context::class);
 

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -11,7 +11,7 @@ namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
 
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
-use Netresearch\NrLlm\Service\Feature\TranslationService;
+use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
 use Netresearch\T3Cowriter\Controller\TranslationController;
 use Netresearch\T3Cowriter\Service\DiagnosticService;
@@ -34,7 +34,7 @@ use TYPO3\CMS\Core\Context\Context;
 #[CoversClass(TranslationController::class)]
 final class TranslationControllerTest extends TestCase
 {
-    private TranslationService&Stub $translationServiceStub;
+    private TranslationServiceInterface&Stub $translationServiceStub;
     private RateLimiterInterface&Stub $rateLimiterStub;
     private BackendUriBuilder&Stub $backendUriBuilderStub;
     private DiagnosticService&Stub $diagnosticServiceStub;
@@ -42,7 +42,7 @@ final class TranslationControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->translationServiceStub = $this->createStub(TranslationService::class);
+        $this->translationServiceStub = $this->createStub(TranslationServiceInterface::class);
         $this->rateLimiterStub        = $this->createStub(RateLimiterInterface::class);
         $this->backendUriBuilderStub  = $this->createStub(BackendUriBuilder::class);
         $this->backendUriBuilderStub->method('buildUriFromRoute')
@@ -332,7 +332,7 @@ final class TranslationControllerTest extends TestCase
         $capturedArgs = [];
 
         // Use a mock to capture exact arguments
-        $translationServiceMock = $this->createMock(TranslationService::class);
+        $translationServiceMock = $this->createMock(TranslationServiceInterface::class);
         $translationServiceMock->expects(self::once())
             ->method('translate')
             ->willReturnCallback(static function (

--- a/Tests/Unit/Controller/VisionControllerTest.php
+++ b/Tests/Unit/Controller/VisionControllerTest.php
@@ -11,7 +11,7 @@ namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
 
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
-use Netresearch\NrLlm\Service\Feature\VisionService;
+use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
 use Netresearch\T3Cowriter\Controller\VisionController;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
 use Netresearch\T3Cowriter\Service\RateLimitResult;
@@ -28,13 +28,13 @@ use TYPO3\CMS\Core\Context\Context;
 #[CoversClass(VisionController::class)]
 final class VisionControllerTest extends TestCase
 {
-    private VisionService&Stub $visionServiceStub;
+    private VisionServiceInterface&Stub $visionServiceStub;
     private RateLimiterInterface&Stub $rateLimiterStub;
     private VisionController $subject;
 
     protected function setUp(): void
     {
-        $this->visionServiceStub = $this->createStub(VisionService::class);
+        $this->visionServiceStub = $this->createStub(VisionServiceInterface::class);
         $this->rateLimiterStub   = $this->createStub(RateLimiterInterface::class);
         $contextStub             = $this->createStub(Context::class);
 


### PR DESCRIPTION
## Problem

CI on `main` failed (run #357) after `netresearch/nr-llm` v0.8 was pulled in via the `>=0.3 <1.0` constraint:

- **18 Unit-test errors** — `TranslationService` and `VisionService` are now `final readonly` and can no longer be doubled by PHPUnit (`ClassIsFinalException`).
- **2 PHPStan errors** — `LlmServiceManagerInterface::chatWithConfiguration()` / `chatWithTools()` tightened their parameters to `list<...>`; `AjaxController:160` and `ToolController:88` passed `array<int, ...>`.

## Fix (adapt the consumer)

- `TranslationController` and `VisionController` now depend on `TranslationServiceInterface` / `VisionServiceInterface`. nr-llm's `Services.yaml` aliases both interfaces to the concrete services, so autowiring is unchanged. Unit/Integration/E2E tests double the **interfaces** instead of the final classes.
- `validateMessages()` (append-only) and `resolveTools()` (`array_values()` / append-only) genuinely return lists — their `@return` annotations are corrected from `array<int, ...>` to `list<...>`. No runtime behavior change.

## Verification (local, PHP 8.5)

- `composer ci:test:php:unit` → **590 tests, 1597 assertions, OK**
- `phpstan analyse` → **No errors**
- `php-cs-fixer` on changed files → clean