### PR TITLE
docs: sync README nr-llm requirement + backfill CHANGELOG (3.1.0, 3.1.1, Unreleased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+# Unreleased
+
+## CHANGE
+
+- Adopt nr-llm 0.22: require `netresearch/nr-llm ^0.22.0` (was 0.3–0.x)
+- Migrate from the removed nr-llm `PromptTemplate` stack to `Task` (nr-llm ADR-069); the CKEditor task dialog now reads tasks from `tx_nrllm_task` with `category = 'content'`
+- Classify LLM failures via nr-llm typed exceptions (`ConfigurationNotFoundException`, `ProviderResponseException` HTTP status) instead of exception-message string-matching
+- Declare LLM tools with the typed `ToolSpec` value object instead of hand-built arrays
+- Raise the TYPO3 v14 floor to v14.3 (nr-llm 0.22 requires `^14.3`, dropping 14.0–14.2)
+- Correct `ext_emconf.php` constraints (`nr_llm` 0.22.0–0.22.99, TYPO3/rte_ckeditor up to 14.99.99) to match `composer.json`
+
+# 3.1.1 (2026-03-24)
+
+## FIX
+
+- Align the `nr_llm` version constraint between `composer.json` and `ext_emconf.php` (>=0.3 <1.0)
+- Address TYPO3 extension assessment findings
+
+## BUILD
+
+- Share the extended-testing CI workflow from `netresearch/typo3-ci-workflows`
+- Remove redundant `phpunit` from `require-dev` (provided by the CI workflows)
+
+# 3.1.0 (2026-03-14)
+
+## FEATURE
+
+- Diagnostic service and "Setup Status" backend module reporting LLM configuration health
+
+## BUILD
+
+- Integrate `netresearch/typo3-ci-workflows` as a Composer package
+- Raise mutation score to 85%+ (MSI) and improve patch coverage
+
+## DOCS
+
+- Replace outdated TYPO3 v11 screenshots with TYPO3 v14 captures
+- Use interlink references for nr-llm documentation
+
 # 3.0.0 (2026-03-10)
 
 ## BREAKING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Classify LLM failures via nr-llm typed exceptions (`ConfigurationNotFoundException`, `ProviderResponseException` HTTP status) instead of exception-message string-matching
 - Declare LLM tools with the typed `ToolSpec` value object instead of hand-built arrays
 - Raise the TYPO3 v14 floor to v14.3 (nr-llm 0.22 requires `^14.3`, dropping 14.0–14.2)
-- Correct `ext_emconf.php` constraints (`nr_llm` 0.22.0–0.22.99, TYPO3/rte_ckeditor up to 14.99.99) to match `composer.json`
+- Correct `ext_emconf.php` constraints: `nr_llm` to 0.22.0–0.22.99 (matching composer `^0.22.0`) and the TYPO3/rte_ckeditor upper bound to 14.99.99. `composer.json` (`^13.4 || ^14.3`) stays authoritative for the TYPO3 range — ext_emconf's single min–max range cannot express the 14.0–14.2 exclusion
 
 # 3.1.1 (2026-03-24)
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ AI-powered content assistant for TYPO3 CKEditor - write better content with help
 ## Requirements
 
 - PHP 8.2+
-- TYPO3 v13 or v14
-- [netresearch/nr-llm](https://github.com/netresearch/t3x-nr-llm) extension (LLM provider abstraction)
+- TYPO3 v13.4 LTS or v14.3 LTS
+- [netresearch/nr-llm](https://github.com/netresearch/t3x-nr-llm) 0.22+ (LLM provider abstraction)
 
 ## Installation
 


### PR DESCRIPTION
## What

Documentation accuracy pass — no code changes.

### README
- **Requirements** now pins `netresearch/nr-llm 0.22+` (it required the extension without stating the version) and tightens the TYPO3 line to **v13.4 LTS or v14.3 LTS** — composer resolves `^13.4 || ^14.3`, which excludes 14.0–14.2, so the previous "v13 or v14" was imprecise.

### CHANGELOG
The changelog stopped at 3.0.0 while **v3.1.0 and v3.1.1 are released tags**. Backfilled both from the tagged history, and added an **Unreleased** section for the nr-llm 0.22 adoption now on `main`:
- **3.1.0** (2026-03-14) — diagnostic service + Setup Status module; `typo3-ci-workflows` as a Composer package; 85% MSI; v14 screenshots.
- **3.1.1** (2026-03-24) — `nr_llm` constraint alignment across `composer.json`/`ext_emconf.php`; extension-assessment fixes; shared extended-testing CI.
- **Unreleased** — nr-llm 0.22: PromptTemplate→Task migration, typed-exception classification, typed `ToolSpec`, TYPO3 v14.3 floor, constraint corrections.

The RST manual (`Documentation/`) and `AGENTS.md` were audited and already accurate — they reference nr-llm via version-less interlinks and carry no removed-class or stale-version references, so they are untouched.

## Verification

Docs-only; no test impact. `category = 'content'` claim verified against `AjaxController::getTasksAction()` → `TaskRepository::findByCategory('content')`; package name `netresearch/t3-cowriter` verified against `composer.json`.