### PR TITLE
fix: non-admin context access + budget attribution + doc drift (audit follow-ups)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 **Project:** t3_cowriter - AI-powered content writing assistant for TYPO3 CKEditor
 **Last Updated:** 2026-03-15
 **Type:** TYPO3 CMS Extension (PHP 8.2+ / JavaScript/ES6)
-**TYPO3:** 13.4 LTS + 14.0
+**TYPO3:** 13.4 LTS + 14.3
 **License:** GPL-3.0-or-later
 
 ## Quick Start
@@ -29,7 +29,7 @@ make urls                    # Show access URLs
 
 - **PHP:** 8.2+ (CI tests 8.2, 8.3, 8.4, 8.5) with extensions: dom, libxml
 - **Composer:** Latest stable
-- **TYPO3:** 13.4 LTS or 14.0+
+- **TYPO3:** 13.4 LTS or 14.3+
 - **DDEV:** For local development
 - **Docker:** For DDEV and docs rendering
 
@@ -53,7 +53,7 @@ ddev install-v14
 | TYPO3 | PHP | Status |
 |-------|-----|--------|
 | 13.4 LTS | 8.2, 8.3, 8.4, 8.5 | Supported |
-| 14.0 | 8.2, 8.3, 8.4, 8.5 | Supported |
+| 14.3 | 8.2, 8.3, 8.4, 8.5 | Supported |
 
 ### Component Overview
 
@@ -131,7 +131,7 @@ CKEditor Toolbar
 **CI is authoritative** - always verify fixes pass in GitHub Actions CI before merging.
 Run tests locally via composer (same as CI), not via DDEV.
 
-CI runs a **multi-version matrix**: PHP 8.2, 8.3, 8.4, 8.5 x TYPO3 ^13.4, ^14.0.
+CI runs a **multi-version matrix**: PHP 8.2, 8.3, 8.4, 8.5 x TYPO3 ^13.4, ^14.3.
 See `.github/workflows/ci.yml` for the full matrix definition.
 
 ### Quality Checks
@@ -186,7 +186,7 @@ All workflows are in `.github/workflows/`. Key workflows:
 
 | Workflow | File | Purpose |
 |----------|------|---------|
-| **CI** | `ci.yml` | Multi-version matrix: PHP 8.2-8.5 x TYPO3 v13.4/v14.0 (lint, phpstan, unit, functional, integration, e2e tests) |
+| **CI** | `ci.yml` | Multi-version matrix: PHP 8.2-8.5 x TYPO3 v13.4/v14.3 (lint, phpstan, unit, functional, integration, e2e tests) |
 | **PR Quality Gates** | `pr-quality.yml` | Auto-approve, Copilot review, merge readiness checks |
 | **Release** | `release.yml` | SBOM generation, Cosign signing, GitHub Release creation, TER publish |
 | **Security** | `security.yml` | Dependency audit, Trivy scanning, security analysis |
@@ -298,6 +298,7 @@ declare(strict_types=1);
 
 namespace Netresearch\T3Cowriter\Controller;
 
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -307,6 +308,7 @@ final readonly class AjaxController
 {
     public function __construct(
         private LlmServiceManagerInterface $llmServiceManager,
+        private LlmConfigurationRepository $configurationRepository,
     ) {}
 
     public function chatAction(ServerRequestInterface $request): ResponseInterface
@@ -314,7 +316,8 @@ final readonly class AjaxController
         $body = json_decode($request->getBody()->getContents(), true);
         $messages = $body['messages'] ?? [];
 
-        $response = $this->llmServiceManager->chat($messages);
+        $configuration = $this->configurationRepository->findDefault();
+        $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration);
 
         return new JsonResponse($response);
     }
@@ -347,7 +350,7 @@ const response = await fetch(TYPO3.settings.ajaxUrls.tx_cowriter_chat, {
 2. **CKEditor 5:** See TYPO3 rte_ckeditor documentation; plugin registered in `Configuration/RTE/Cowriter.yaml`
 3. **AJAX Routes:** Check `Configuration/Backend/AjaxRoutes.php`
 4. **DI Issues:** Verify `Configuration/Services.yaml` registration
-5. **Version compatibility:** Code must work on both TYPO3 v13.4 and v14.0; check CI matrix in `.github/workflows/ci.yml`
+5. **Version compatibility:** Code must work on both TYPO3 v13.4 and v14.3; check CI matrix in `.github/workflows/ci.yml`
 
 ### Common Issues
 
@@ -367,7 +370,7 @@ const response = await fetch(TYPO3.settings.ajaxUrls.tx_cowriter_chat, {
 
 ### Dependencies
 
-- **Supported versions:** TYPO3 13.4 LTS + 14.0, PHP 8.2+
+- **Supported versions:** TYPO3 13.4 LTS + 14.3, PHP 8.2+
 - **Renovate:** Auto-updates enabled
 - **nr-llm:** Primary LLM abstraction layer
 
@@ -385,7 +388,7 @@ const response = await fetch(TYPO3.settings.ajaxUrls.tx_cowriter_chat, {
 - **[Tests/AGENTS.md](Tests/AGENTS.md)** - Test suite structure
 
 **Configuration:**
-- **[composer.json](composer.json)** - Dependencies & scripts (PHP ^8.2, TYPO3 ^13.4 || ^14.0)
+- **[composer.json](composer.json)** - Dependencies & scripts (PHP ^8.2, TYPO3 ^13.4 || ^14.3)
 - **[Configuration/RTE/Cowriter.yaml](Configuration/RTE/Cowriter.yaml)** - CKEditor plugin registration
 - **[Build/](Build/)** - Development tools configuration
 

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -46,17 +46,21 @@ public function __construct(
 ## Security (CRITICAL)
 
 ```php
-// ALWAYS escape LLM output to prevent XSS
-content: htmlspecialchars($response->content, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+// LLM output is returned RAW in JSON — do NOT htmlspecialchars() it server-side.
+// The frontend sanitizes it via a DOMParser-based pipeline before it enters the
+// editor; escaping here would double-encode and break that contract.
+content: $response->content,
 ```
 
 ## nr-llm Integration
 
 ```php
-// Use LlmServiceManagerInterface for all LLM operations
+// Use LlmServiceManagerInterface for all LLM operations. Resolve a configuration
+// and pass the backend user id as budget metadata so per-user nr-llm
+// BudgetMiddleware enforcement applies to the call.
 $configuration = $this->configurationRepository->findDefault();
-$options = $configuration->toChatOptions();
-$response = $this->llmServiceManager->chat($messages, $options);
+$metadata      = [BudgetMiddleware::METADATA_BE_USER_UID => $beUserUid];
+$response      = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $metadata);
 ```
 
 ### Response Handling
@@ -64,10 +68,11 @@ $response = $this->llmServiceManager->chat($messages, $options);
 ```php
 // Handle errors gracefully with diagnostic messages
 try {
-    $response = $this->llmServiceManager->chat($messages, $options);
+    $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $metadata);
     return CompleteResponse::success($response);
 } catch (ProviderException $e) {
-    // enrichErrorMessage checks DiagnosticService for specific failures
+    // enrichErrorMessage classifies the failure via LlmErrorClassifier and adds
+    // a Setup-Status link for configuration errors.
     return $this->buildErrorResponse('LLM provider error occurred.', $e);
 } catch (\Throwable $e) {
     return $this->buildErrorResponse('An unexpected error occurred.', $e);
@@ -146,7 +151,7 @@ public static function success(CompletionResponse $response): self
 ## PR/Commit Checklist
 
 1. **PHPStan level 10:** Zero errors
-2. **HTML escaping:** All LLM output escaped
+2. **Output contract:** LLM output returned raw, sanitized on the frontend (no server-side escaping)
 3. **Exception handling:** ProviderException, RateLimitResult handling
 4. **Type safety:** All properties typed
 5. **Tests first:** TDD approach
@@ -172,7 +177,7 @@ public function completeAction(ServerRequestInterface $request): ResponseInterfa
     }
 
     try {
-        $response = $this->llmServiceManager->chat($messages, $options);
+        $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration);
         return new JsonResponse(
             CompleteResponse::success($response)->jsonSerialize()
         );
@@ -188,12 +193,12 @@ public function completeAction(ServerRequestInterface $request): ResponseInterfa
 ### Bad: Missing Error Handling
 
 ```php
-// DON'T: No error handling, no HTML escaping
+// DON'T: no rate limiting, no input validation, no error handling
 public function completeAction($request)
 {
     $body = json_decode($request->getBody()->getContents(), true);
-    $response = $this->llmServiceManager->chat($body['messages']);
-    return new JsonResponse(['content' => $response->content]); // XSS risk!
+    $response = $this->llmServiceManager->chatWithConfiguration($body['messages'], $configuration);
+    return new JsonResponse(['content' => $response->content]); // unhandled ProviderException, no rate limit
 }
 ```
 

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\T3Cowriter\Domain\DTO\CompleteRequest;
 use Netresearch\T3Cowriter\Domain\DTO\CompleteResponse;
@@ -162,7 +163,7 @@ final readonly class AjaxController
         }
 
         try {
-            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration);
+            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $this->budgetMetadata());
 
             return $this->jsonResponseWithRateLimitHeaders([
                 'success'      => true,
@@ -256,7 +257,7 @@ final readonly class AjaxController
                 ['role' => 'user', 'content' => $dto->prompt],
             ];
 
-            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration);
+            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $this->budgetMetadata());
 
             return $this->jsonResponseWithRateLimitHeaders(
                 CompleteResponse::success($response)->jsonSerialize(),
@@ -335,7 +336,7 @@ final readonly class AjaxController
         // This implementation collects chunks and returns them in SSE format for compatibility
         try {
             $chunks    = [];
-            $generator = $this->llmServiceManager->streamChatWithConfiguration($messages, $configuration);
+            $generator = $this->llmServiceManager->streamChatWithConfiguration($messages, $configuration, [], $this->budgetMetadata());
 
             foreach ($generator as $chunk) {
                 $chunks[] = 'data: ' . json_encode(['content' => $chunk], JSON_THROW_ON_ERROR) . "\n\n";
@@ -632,7 +633,7 @@ final readonly class AjaxController
         }
 
         try {
-            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration);
+            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $this->budgetMetadata());
 
             // Post-process: convert markdown to HTML if the model ignored the formatting instruction
             $rawContent       = $response->content;
@@ -882,10 +883,30 @@ final readonly class AjaxController
      */
     private function checkRateLimit(): RateLimitResult
     {
+        return $this->rateLimiter->checkLimit((string) $this->currentBackendUserId());
+    }
+
+    /**
+     * The current backend user id, or 0 when there is no session.
+     */
+    private function currentBackendUserId(): int
+    {
         /** @var int|string $userId */
         $userId = $this->context->getPropertyFromAspect('backend.user', 'id', 0);
 
-        return $this->rateLimiter->checkLimit((string) $userId);
+        return (int) $userId;
+    }
+
+    /**
+     * nr-llm budget-attribution metadata for the current backend user, so
+     * per-user BudgetMiddleware enforcement applies to cowriter traffic.
+     * A uid of 0 (no session) is passed through and skipped by the middleware.
+     *
+     * @return array<string, int>
+     */
+    private function budgetMetadata(): array
+    {
+        return [BudgetMiddleware::METADATA_BE_USER_UID => $this->currentBackendUserId()];
     }
 
     /**

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -88,10 +88,10 @@ final readonly class TranslationController
         }
 
         try {
-            $options = new TranslationOptions(
+            $options = (new TranslationOptions(
                 formality: $translationRequest->formality,
                 domain: $translationRequest->domain,
-            );
+            ))->withBeUserUid((int) $userId);
 
             // When an editor pins a stored configuration, route through the
             // per-configuration path (nr-llm 0.22, #428) so the configuration's

--- a/Classes/Controller/VisionController.php
+++ b/Classes/Controller/VisionController.php
@@ -74,7 +74,7 @@ final readonly class VisionController
         }
 
         try {
-            $options  = new VisionOptions();
+            $options  = (new VisionOptions())->withBeUserUid((int) $userId);
             $response = $this->visionService->analyzeImageFull(
                 $visionRequest->imageUrl,
                 $visionRequest->prompt,

--- a/Classes/Domain/DTO/CompleteResponse.php
+++ b/Classes/Domain/DTO/CompleteResponse.php
@@ -117,11 +117,8 @@ final readonly class CompleteResponse implements JsonSerializable
     /**
      * Create a rate-limited response with retry information.
      *
-     * Note: Currently unused as nr-llm does not expose RateLimitException.
-     * This method is prepared for future integration when rate limiting
-     * is supported by the nr-llm provider abstraction layer.
-     *
-     * @see https://github.com/netresearch/t3x-nr-llm/issues - Track rate limit support
+     * Used by AjaxController on the 429 path when the cowriter RateLimiterService
+     * (20 requests/minute per backend user) denies a request.
      */
     public static function rateLimited(int $retryAfter): self
     {

--- a/Classes/Service/ContextAssemblyService.php
+++ b/Classes/Service/ContextAssemblyService.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\T3Cowriter\Service;
 
-use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
@@ -56,9 +55,27 @@ final readonly class ContextAssemblyService implements ContextAssemblyServiceInt
             return true;
         }
 
-        $page = BackendUtility::getRecord('pages', $pid, 'uid');
+        // Fetch the permission columns core calcPerms() needs. A uid-only row
+        // makes calcPerms() return Permission::NOTHING for every non-admin, so
+        // the row MUST carry perms_userid/perms_user/perms_groupid/perms_group/
+        // perms_everybody for the access check to reflect the user's real rights.
+        $qb   = $this->connectionPool->getQueryBuilderForTable('pages');
+        $page = $qb
+            ->select(
+                'uid',
+                'pid',
+                'perms_userid',
+                'perms_groupid',
+                'perms_user',
+                'perms_group',
+                'perms_everybody',
+            )
+            ->from('pages')
+            ->where($qb->expr()->eq('uid', $qb->createNamedParameter($pid)))
+            ->executeQuery()
+            ->fetchAssociative();
 
-        return $page !== null && $backendUser->doesUserHaveAccess($page, 1);
+        return $page !== false && $backendUser->doesUserHaveAccess($page, 1);
     }
 
     /**

--- a/Documentation/Api/Index.rst
+++ b/Documentation/Api/Index.rst
@@ -75,9 +75,10 @@ Returns ``text/event-stream`` with JSON chunks:
 
 .. code-block:: text
 
-    data: {"content": "TYPO3 ", "done": false}
-    data: {"content": "is a ", "done": false}
-    data: {"content": "powerful...", "done": true, "model": "gpt-5.2"}
+    data: {"content": "TYPO3 "}
+    data: {"content": "is a "}
+    data: {"content": "powerful..."}
+    data: {"done": true, "model": "gpt-5.2"}
 
 .. _api-task-execute:
 
@@ -91,15 +92,20 @@ Execute a predefined task with context assembly.
 .. code-block:: json
 
     {
-        "taskIdentifier": "improve-text",
+        "taskUid": 12,
         "instruction": "Improve this text",
         "context": "<p>Current editor content</p>",
-        "contextScope": "content_element",
+        "contextType": "content_element",
+        "contextScope": "element",
         "configuration": "openai-default",
         "referencePages": [
             {"pid": 42, "relation": "style guide"}
         ]
     }
+
+``taskUid`` is the ``tx_nrllm_task`` record uid. ``contextType`` is one of
+``selection`` or ``content_element``; ``contextScope`` is one of ``selection``,
+``text``, ``element``, ``page``, ``ancestors_1``, ``ancestors_2``.
 
 Translation
 ===========

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -48,7 +48,8 @@ Features
 *   **Ad-hoc instructions**: Add custom instructions per request
 *   **Rate limiting**: 20 requests/minute per backend user
 *   **Streaming**: Server-Sent Events for real-time completions
-*   **XSS Protection**: All LLM output is HTML-escaped for defense in depth
+*   **XSS Protection**: LLM output is returned raw and sanitized on the frontend
+    via a DOMParser-based pipeline before insertion into the editor
 *   Support for TYPO3 v13.4 and v14
 *   Compatible with PHP 8.2 — 8.5
 

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\T3Cowriter\Controller\AjaxController;
 use Netresearch\T3Cowriter\Service\ContextAssemblyServiceInterface;
@@ -148,6 +149,31 @@ final class AjaxControllerTest extends TestCase
         $this->assertSame('test-model', $data['model']);
         $this->assertArrayHasKey('finishReason', $data);
         $this->assertSame('stop', $data['finishReason']);
+    }
+
+    #[Test]
+    public function chatActionThreadsBudgetMetadataWithBackendUserId(): void
+    {
+        $messages = [
+            ['role' => 'user', 'content' => 'Hello'],
+        ];
+        $config = $this->createConfigurationMock();
+        $this->configRepositoryMock->method('findDefault')->willReturn($config);
+
+        $captured = null;
+        $this->llmServiceManagerMock
+            ->method('chatWithConfiguration')
+            ->willReturnCallback(function (array $m, $c, array $metadata = []) use (&$captured): CompletionResponse {
+                $captured = $metadata;
+
+                return $this->createCompletionResponse('Hi');
+            });
+
+        $request = $this->createRequestWithJsonBody(['messages' => $messages]);
+        $this->subject->chatAction($request);
+
+        // contextMock->getPropertyFromAspect returns 1 for the backend user id.
+        self::assertSame([BudgetMiddleware::METADATA_BE_USER_UID => 1], $captured);
     }
 
     #[Test]

--- a/Tests/Unit/Service/ContextAssemblyServiceTest.php
+++ b/Tests/Unit/Service/ContextAssemblyServiceTest.php
@@ -162,6 +162,56 @@ final class ContextAssemblyServiceTest extends TestCase
     }
 
     #[Test]
+    public function nonAdminWithPageAccessReceivesContext(): void
+    {
+        // Regression: userHasPageAccess() previously fetched a uid-only page
+        // row, so core calcPerms() returned Permission::NOTHING and denied
+        // EVERY non-admin editor. The access decision must be driven by a row
+        // that carries the perms_* columns. This models doesUserHaveAccess()
+        // granting access iff those columns are present on the fetched row.
+        $backendUser = $this->createStub(BackendUserAuthentication::class);
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('doesUserHaveAccess')->willReturnCallback(
+            static fn (array $row): bool => isset($row['perms_everybody']),
+        );
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $connectionPool = $this->createConnectionPoolMock([
+            // 1st fetch: the tt_content element being summarised.
+            ['uid' => 123, 'pid' => 5, 'header' => 'Test', 'bodytext' => '<p>One two three four</p>', 'subheader' => ''],
+            // 2nd fetch: the page row, now carrying the permission columns.
+            ['uid' => 5, 'pid' => 0, 'perms_userid' => 1, 'perms_groupid' => 0, 'perms_user' => 31, 'perms_group' => 0, 'perms_everybody' => 1],
+        ]);
+
+        $service = new ContextAssemblyService($connectionPool);
+        $result  = $service->getContextSummary('tt_content', 123, 'bodytext', 'element');
+
+        self::assertGreaterThan(0, $result['wordCount']);
+    }
+
+    #[Test]
+    public function nonAdminWithoutPageAccessReceivesNoContext(): void
+    {
+        $backendUser = $this->createStub(BackendUserAuthentication::class);
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('doesUserHaveAccess')->willReturnCallback(
+            static fn (array $row): bool => isset($row['perms_everybody']),
+        );
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $connectionPool = $this->createConnectionPoolMock([
+            ['uid' => 123, 'pid' => 5, 'header' => 'Test', 'bodytext' => '<p>One two three four</p>', 'subheader' => ''],
+            // Page row without perms_everybody set → access denied.
+            ['uid' => 5, 'pid' => 0, 'perms_userid' => 99, 'perms_groupid' => 0, 'perms_user' => 0, 'perms_group' => 0],
+        ]);
+
+        $service = new ContextAssemblyService($connectionPool);
+        $result  = $service->getContextSummary('tt_content', 123, 'bodytext', 'element');
+
+        self::assertSame(0, $result['wordCount']);
+    }
+
+    #[Test]
     public function countWordsStripsHtmlTags(): void
     {
         $service = new ContextAssemblyService($this->createConnectionPoolMock([]));


### PR DESCRIPTION
Follow-ups from a multi-dimensional audit of the extension after the nr-llm 0.22 upgrade. Three atomic commits; the clearly-correct, low-risk findings only (behavioral/architectural findings are tracked separately — see below).

## 1. fix: non-admin editors were denied all surrounding context (HIGH)

`ContextAssemblyService::userHasPageAccess()` fetched a **uid-only** page row via `BackendUtility::getRecord('pages', $pid, 'uid')`. TYPO3 core `calcPerms()` only ORs permission bits in when the row carries `perms_userid/perms_user/perms_groupid/perms_group/perms_everybody`; a uid-only row yields `Permission::NOTHING`, so **every non-admin editor** was denied and the surrounding-context feature (scopes element/page/ancestors + reference pages) silently produced nothing — it worked only for admins.

Fix: query the page row (with the `perms_*` columns) through the injected `ConnectionPool`, which also removes the last static `BackendUtility` dependency and makes the path unit-testable. Added non-admin allow/deny regression tests (the prior single test only mocked `isAdmin()=true` and never exercised this path).

## 2. feat: attribute LLM calls to the backend user for nr-llm budget enforcement

nr-llm 0.22 `BudgetMiddleware` reads a `beUserUid` off call metadata/options; absent/0 skips the per-user check. Cowriter passed neither, so **per-user budgets configured in nr_llm were never enforced** for cowriter traffic. Threads the BE user id (already resolved for rate limiting) into every LLM entrypoint: chat/complete/task via `chatWithConfiguration`'s `$metadata`, stream via `streamChatWithConfiguration`'s trailing `$metadata`, and `withBeUserUid()` on Vision/Translation options. Tool calling is deferred (ToolOptions carries no budget field — needs the configuration-based tool entrypoint).

> Note: this **activates** per-user budget enforcement that was previously bypassed. A global cap already applied, so spend was never unbounded, but any per-user daily budget now takes effect for cowriter.

## 3. docs: correct API/agent doc drift

- API task-execute example used a nonexistent `taskIdentifier` and an invalid `contextScope` (`content_element` is a contextType) → `taskUid` + real `contextType`/`contextScope` values; SSE example corrected to match `streamAction` output.
- Introduction: the extension does not HTML-escape output server-side — it returns raw and sanitizes on the frontend via DOMParser.
- AGENTS.md / Classes/AGENTS.md: TYPO3 `14.0` → `14.3` (matches composer `^13.4 || ^14.3`); replaced the removed `chat()`/`toChatOptions()` examples with `chatWithConfiguration()` + budget metadata; removed the server-side `htmlspecialchars()` guidance that contradicts the sanitize-on-frontend model.
- `CompleteResponse::rateLimited()`: dropped the false "currently unused" docblock (it is live on the 429 path).

## Deferred (behavioral/architectural — not in this PR)

The audit also surfaced, for a separate decision: extract shared controller plumbing into a trait/presenter (dedup); route tool calling through `chatWithToolsForConfiguration` + wire `ToolLoopService` so `query_content` actually executes (currently declared to the model but never run); `VisionOptions::altText()` preset; `translateForConfiguration()` when a configuration id is supplied; and tool allow-list test coverage.

## Verification

Full local gate: PHPStan level 10 ✅, unit 600 ✅, integration 30 ✅, e2e 86 ✅, cgl ✅, rector ✅.