### PR TITLE
feat(translation): route pinned configurations through translateForConfiguration

### DIFF
--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -12,6 +12,7 @@ namespace Netresearch\T3Cowriter\Controller;
 use JsonException;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
 use Netresearch\T3Cowriter\Domain\DTO\TranslationRequest;
@@ -153,8 +154,15 @@ final readonly class TranslationController
 
     /**
      * Resolve a pinned configuration by identifier. Returns null when no
-     * identifier was supplied or none matches, so translation falls back to
-     * the default LLM path.
+     * identifier was supplied, so translation uses the default LLM path.
+     *
+     * A requested-but-unknown identifier is an error, not a silent fallback:
+     * falling back would apply the default persona/tone/model instead of the
+     * one the editor asked for, without anyone noticing. The thrown exception
+     * is caught in translateAction() and surfaced as a configuration error.
+     *
+     * @throws ConfigurationNotFoundException when $identifier is given but no
+     *                                        matching configuration exists
      */
     private function resolveConfiguration(?string $identifier): ?LlmConfiguration
     {
@@ -162,7 +170,15 @@ final readonly class TranslationController
             return null;
         }
 
-        return $this->configurationRepository->findOneByIdentifier($identifier);
+        $configuration = $this->configurationRepository->findOneByIdentifier($identifier);
+        if (!$configuration instanceof LlmConfiguration) {
+            throw new ConfigurationNotFoundException(
+                sprintf('LLM configuration "%s" not found.', $identifier),
+                1784419200,
+            );
+        }
+
+        return $configuration;
     }
 
     /**

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\T3Cowriter\Controller;
 
 use JsonException;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
 use Netresearch\T3Cowriter\Domain\DTO\TranslationRequest;
@@ -36,6 +38,7 @@ final readonly class TranslationController
 {
     public function __construct(
         private TranslationServiceInterface $translationService,
+        private LlmConfigurationRepository $configurationRepository,
         private RateLimiterInterface $rateLimiter,
         private Context $context,
         private LoggerInterface $logger,
@@ -87,15 +90,28 @@ final readonly class TranslationController
             $options = new TranslationOptions(
                 formality: $translationRequest->formality,
                 domain: $translationRequest->domain,
-                provider: $translationRequest->configuration,
             );
 
-            $result = $this->translationService->translate(
-                $translationRequest->text,
-                $translationRequest->targetLanguage,
-                null,
-                $options,
-            );
+            // When an editor pins a stored configuration, route through the
+            // per-configuration path (nr-llm 0.22, #428) so the configuration's
+            // persona/tone, model and provider apply; otherwise use the plain
+            // LLM translation path.
+            $configuration = $this->resolveConfiguration($translationRequest->configuration);
+
+            $result = $configuration instanceof LlmConfiguration
+                ? $this->translationService->translateForConfiguration(
+                    $translationRequest->text,
+                    $translationRequest->targetLanguage,
+                    $configuration,
+                    null,
+                    $options,
+                )
+                : $this->translationService->translate(
+                    $translationRequest->text,
+                    $translationRequest->targetLanguage,
+                    null,
+                    $options,
+                );
 
             return $this->jsonResponseWithRateLimitHeaders([
                 'success'        => true,
@@ -133,6 +149,20 @@ final readonly class TranslationController
                 500,
             );
         }
+    }
+
+    /**
+     * Resolve a pinned configuration by identifier. Returns null when no
+     * identifier was supplied or none matches, so translation falls back to
+     * the default LLM path.
+     */
+    private function resolveConfiguration(?string $identifier): ?LlmConfiguration
+    {
+        if ($identifier === null || $identifier === '') {
+            return null;
+        }
+
+        return $this->configurationRepository->findOneByIdentifier($identifier);
     }
 
     /**

--- a/Tests/E2E/NewFeatureWorkflowTest.php
+++ b/Tests/E2E/NewFeatureWorkflowTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\T3Cowriter\Tests\E2E;
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
@@ -119,6 +120,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
 
         $controller = new TranslationController(
             $translationService,
+            $this->createMock(LlmConfigurationRepository::class),
             $rateLimiter,
             $context,
             $this->logger,
@@ -386,6 +388,7 @@ final class NewFeatureWorkflowTest extends AbstractE2ETestCase
 
         $controller = new TranslationController(
             $stack['translationService'],
+            $this->createMock(LlmConfigurationRepository::class),
             $stack['rateLimiter'],
             $stack['context'],
             $this->logger,

--- a/Tests/Integration/Controller/TranslationControllerIntegrationTest.php
+++ b/Tests/Integration/Controller/TranslationControllerIntegrationTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\T3Cowriter\Tests\Integration\Controller;
 
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\T3Cowriter\Controller\TranslationController;
 use Netresearch\T3Cowriter\Service\DiagnosticService;
@@ -65,8 +66,11 @@ final class TranslationControllerIntegrationTest extends AbstractIntegrationTest
         $diagnosticServiceMock = $this->createMock(DiagnosticService::class);
         $diagnosticServiceMock->method('runFirst')->willReturn(new DiagnosticResult(true, []));
 
+        $configurationRepositoryMock = $this->createMock(LlmConfigurationRepository::class);
+
         $this->subject = new TranslationController(
             $this->translationServiceMock,
+            $configurationRepositoryMock,
             $this->rateLimiterMock,
             $this->contextMock,
             new NullLogger(),

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
@@ -37,6 +39,7 @@ use TYPO3\CMS\Core\Context\Context;
 final class TranslationControllerTest extends TestCase
 {
     private TranslationServiceInterface&Stub $translationServiceStub;
+    private LlmConfigurationRepository&Stub $configurationRepositoryStub;
     private RateLimiterInterface&Stub $rateLimiterStub;
     private BackendUriBuilder&Stub $backendUriBuilderStub;
     private DiagnosticService&Stub $diagnosticServiceStub;
@@ -44,9 +47,10 @@ final class TranslationControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->translationServiceStub = $this->createStub(TranslationServiceInterface::class);
-        $this->rateLimiterStub        = $this->createStub(RateLimiterInterface::class);
-        $this->backendUriBuilderStub  = $this->createStub(BackendUriBuilder::class);
+        $this->translationServiceStub      = $this->createStub(TranslationServiceInterface::class);
+        $this->configurationRepositoryStub = $this->createStub(LlmConfigurationRepository::class);
+        $this->rateLimiterStub             = $this->createStub(RateLimiterInterface::class);
+        $this->backendUriBuilderStub       = $this->createStub(BackendUriBuilder::class);
         $this->backendUriBuilderStub->method('buildUriFromRoute')
             ->willReturn(new \TYPO3\CMS\Core\Http\Uri('/typo3/module/cowriter/status'));
         $this->diagnosticServiceStub = $this->createStub(DiagnosticService::class);
@@ -60,6 +64,7 @@ final class TranslationControllerTest extends TestCase
 
         $this->subject = new TranslationController(
             $this->translationServiceStub,
+            $this->configurationRepositoryStub,
             $this->rateLimiterStub,
             $contextStub,
             new NullLogger(),
@@ -296,6 +301,7 @@ final class TranslationControllerTest extends TestCase
 
         $controller = new TranslationController(
             $this->translationServiceStub,
+            $this->configurationRepositoryStub,
             $this->rateLimiterStub,
             $contextStub,
             new NullLogger(),
@@ -317,7 +323,7 @@ final class TranslationControllerTest extends TestCase
     }
 
     #[Test]
-    public function translateActionPassesConfigurationAsProviderNotSourceLanguage(): void
+    public function translateActionRoutesThroughConfigurationWhenPinned(): void
     {
         $this->rateLimiterStub->method('checkLimit')
             ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
@@ -330,11 +336,86 @@ final class TranslationControllerTest extends TestCase
             usage: new UsageStatistics(50, 30, 80),
         );
 
-        /** @var list<array{string, string, ?string, TranslationOptions}> */
+        $configuration = $this->createStub(LlmConfiguration::class);
+
+        $configurationRepositoryMock = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepositoryMock->expects(self::once())
+            ->method('findOneByIdentifier')
+            ->with('editorial-tone')
+            ->willReturn($configuration);
+
+        /** @var list<array{string, string, LlmConfiguration, ?string, ?TranslationOptions}> */
         $capturedArgs = [];
 
-        // Use a mock to capture exact arguments
         $translationServiceMock = $this->createMock(TranslationServiceInterface::class);
+        $translationServiceMock->expects(self::never())->method('translate');
+        $translationServiceMock->expects(self::once())
+            ->method('translateForConfiguration')
+            ->willReturnCallback(static function (
+                string $text,
+                string $targetLanguage,
+                LlmConfiguration $config,
+                ?string $sourceLanguage,
+                ?TranslationOptions $options,
+            ) use (&$capturedArgs, $translationResult): TranslationResult {
+                $capturedArgs[] = [$text, $targetLanguage, $config, $sourceLanguage, $options];
+
+                return $translationResult;
+            });
+
+        $contextStub = $this->createStub(Context::class);
+        $contextStub->method('getPropertyFromAspect')->willReturn(1);
+
+        $controller = new TranslationController(
+            $translationServiceMock,
+            $configurationRepositoryMock,
+            $this->rateLimiterStub,
+            $contextStub,
+            new NullLogger(),
+            $this->backendUriBuilderStub,
+            $this->diagnosticServiceStub,
+        );
+
+        $request = $this->createJsonRequest([
+            'text'           => 'Hello world',
+            'targetLanguage' => 'de',
+            'configuration'  => 'editorial-tone',
+            'formality'      => 'formal',
+        ]);
+        $response = $controller->translateAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(1, $capturedArgs);
+
+        [$text, $targetLang, $config, $sourceLang, $options] = $capturedArgs[0];
+        self::assertSame('Hello world', $text);
+        self::assertSame('de', $targetLang);
+        self::assertSame($configuration, $config, 'the resolved configuration must be forwarded');
+        self::assertNull($sourceLang, 'sourceLanguage must be null, not the configuration value');
+        self::assertInstanceOf(TranslationOptions::class, $options);
+        self::assertNull($options->getProvider(), 'the configuration identifier must not leak into provider');
+        self::assertSame('formal', $options->getFormality());
+    }
+
+    #[Test]
+    public function translateActionUsesPlainPathWithNullSourceLanguageWhenNoConfiguration(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $translationResult = new TranslationResult(
+            translation: 'Hallo Welt',
+            sourceLanguage: 'en',
+            targetLanguage: 'de',
+            confidence: 0.9,
+            usage: new UsageStatistics(50, 30, 80),
+        );
+
+        /** @var list<array{string, string, ?string, ?TranslationOptions}> */
+        $capturedArgs = [];
+
+        $translationServiceMock = $this->createMock(TranslationServiceInterface::class);
+        $translationServiceMock->expects(self::never())->method('translateForConfiguration');
         $translationServiceMock->expects(self::once())
             ->method('translate')
             ->willReturnCallback(static function (
@@ -353,6 +434,7 @@ final class TranslationControllerTest extends TestCase
 
         $controller = new TranslationController(
             $translationServiceMock,
+            $this->configurationRepositoryStub,
             $this->rateLimiterStub,
             $contextStub,
             new NullLogger(),
@@ -363,7 +445,6 @@ final class TranslationControllerTest extends TestCase
         $request = $this->createJsonRequest([
             'text'           => 'Hello world',
             'targetLanguage' => 'de',
-            'configuration'  => 'my-provider',
             'formality'      => 'formal',
         ]);
         $response = $controller->translateAction($request);
@@ -376,7 +457,6 @@ final class TranslationControllerTest extends TestCase
         self::assertSame('de', $targetLang);
         self::assertNull($sourceLang, 'sourceLanguage must be null, not the configuration value');
         self::assertInstanceOf(TranslationOptions::class, $options);
-        self::assertSame('my-provider', $options->getProvider());
         self::assertSame('formal', $options->getFormality());
     }
 

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -460,6 +460,52 @@ final class TranslationControllerTest extends TestCase
         self::assertSame('formal', $options->getFormality());
     }
 
+    #[Test]
+    public function translateActionReturnsErrorWhenPinnedConfigurationNotFound(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $configurationRepositoryMock = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepositoryMock->expects(self::once())
+            ->method('findOneByIdentifier')
+            ->with('missing-config')
+            ->willReturn(null);
+
+        // A requested configuration that does not exist must not silently fall
+        // back to the default translation path.
+        $translationServiceMock = $this->createMock(TranslationServiceInterface::class);
+        $translationServiceMock->expects(self::never())->method('translateForConfiguration');
+        $translationServiceMock->expects(self::never())->method('translate');
+
+        $contextStub = $this->createStub(Context::class);
+        $contextStub->method('getPropertyFromAspect')->willReturn(1);
+
+        $controller = new TranslationController(
+            $translationServiceMock,
+            $configurationRepositoryMock,
+            $this->rateLimiterStub,
+            $contextStub,
+            new NullLogger(),
+            $this->backendUriBuilderStub,
+            $this->diagnosticServiceStub,
+        );
+
+        $request = $this->createJsonRequest([
+            'text'           => 'Hello world',
+            'targetLanguage' => 'de',
+            'configuration'  => 'missing-config',
+        ]);
+        $response = $controller->translateAction($request);
+
+        self::assertSame(500, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertFalse($data['success']);
+        self::assertNotSame('', $data['error']);
+        // Classified as a configuration error, so the status-page link is offered.
+        self::assertArrayHasKey('statusUrl', $data);
+    }
+
     /**
      * @param array<string, mixed> $body
      */


### PR DESCRIPTION
## Summary

nr-llm on `main` is already `^0.22.0` (resolves v0.22.0); the version bump is a no-op. This PR adopts the one 0.22 capability that fits cowriter and was not yet present: per-configuration translation.

## Change

`TranslationController` previously passed the editor-selected configuration identifier into `TranslationOptions(provider: <configId>)`. `TranslationService::translate()` interprets `provider` as a provider name and ignores the stored configuration, so the pinned configuration's persona/tone/model never applied.

nr-llm 0.22 (#428) adds `TranslationService::translateForConfiguration()`, which routes through `chatWithConfiguration()` so the configuration's `system_prompt`, model and provider apply. The controller now:

- injects `LlmConfigurationRepository` and resolves the identifier to an `LlmConfiguration`,
- calls `translateForConfiguration()` when a configuration is pinned,
- falls back to the plain `translate()` path (unchanged default behavior) when none is pinned.

## Tests

- Rewrote the config-path unit test to assert `translateForConfiguration()` is called with the resolved configuration and that the identifier no longer leaks into `provider`.
- Added a plain-path test asserting `translate()` is used with `sourceLanguage = null` when no configuration is pinned.
- Updated the manual `TranslationController` constructions in the integration and E2E tests for the new dependency.

## Not adopted (assessed, out of scope)

- Named-configuration completion (ADR-077): cowriter routes completions through `chatWithConfiguration()` with its own writing-assistant system prompt; it does not use `CompletionService`.
- First-party fakes (ADR-079): tests use PHPUnit stubs against nr-llm interfaces; no hand-rolled fakes to replace.
- Reranker / document understanding / rank fusion / keyword search: retrieval capabilities, no surface in cowriter.

## Follow-ups

- Consider `ConfigurationResolver::getActiveByIdentifier()` (ADR-070) across `AjaxController` + `TranslationController` for isActive/access-guarded resolution with typed exceptions.
- The translate UI sends no configuration yet; a picker would surface the per-configuration tone to editors.

## Gates

phplint, phpstan (level 10), php-cs-fixer, rector clean; phpunit unit/integration/e2e green.