### PR TITLE
refactor: dedup controller plumbing + vision altText preset + tool allow-list tests

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -921,11 +921,8 @@ final readonly class AjaxController
             429,
         );
 
-        foreach ($result->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
+        return $this->addRateLimitHeaders($response, $result)
+            ->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
     }
 
     /**

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -55,6 +55,8 @@ use TYPO3\CMS\Core\Type\Bitmask\Permission;
  */
 final readonly class AjaxController
 {
+    use RateLimitedControllerTrait;
+
     /**
      * Maximum number of messages in a chat conversation.
      */
@@ -924,25 +926,6 @@ final readonly class AjaxController
         }
 
         return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
-    }
-
-    /**
-     * Create JSON response with rate limit headers.
-     *
-     * @param array<string, mixed> $data
-     */
-    private function jsonResponseWithRateLimitHeaders(
-        array $data,
-        RateLimitResult $rateLimitResult,
-        int $statusCode = 200,
-    ): JsonResponse {
-        $response = new JsonResponse($data, $statusCode);
-
-        foreach ($rateLimitResult->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response;
     }
 
     /**

--- a/Classes/Controller/RateLimitedControllerTrait.php
+++ b/Classes/Controller/RateLimitedControllerTrait.php
@@ -64,13 +64,7 @@ trait RateLimitedControllerTrait
         RateLimitResult $rateLimitResult,
         int $statusCode = 200,
     ): JsonResponse {
-        $response = new JsonResponse($data, $statusCode);
-
-        foreach ($rateLimitResult->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response;
+        return $this->addRateLimitHeaders(new JsonResponse($data, $statusCode), $rateLimitResult);
     }
 
     /**
@@ -84,10 +78,19 @@ trait RateLimitedControllerTrait
             429,
         );
 
+        return $this->addRateLimitHeaders($response, $result)
+            ->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
+    }
+
+    /**
+     * Copy the rate-limit headers from the result onto a response.
+     */
+    private function addRateLimitHeaders(JsonResponse $response, RateLimitResult $result): JsonResponse
+    {
         foreach ($result->getHeaders() as $name => $value) {
             $response = $response->withAddedHeader($name, $value);
         }
 
-        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
+        return $response;
     }
 }

--- a/Classes/Controller/RateLimitedControllerTrait.php
+++ b/Classes/Controller/RateLimitedControllerTrait.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Controller;
+
+use JsonException;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * Shared request-parsing and rate-limit response plumbing for the cowriter
+ * AJAX controllers. These helpers were byte-identical copies across the
+ * controllers; keeping them in one trait removes the duplication (and the
+ * SonarCloud new-code duplication it triggered).
+ *
+ * A controller that needs a different rate-limited body (e.g. AjaxController,
+ * which serialises a CompleteResponse) simply declares its own
+ * {@see self::rateLimitedResponse()} — a class method overrides the trait's.
+ */
+trait RateLimitedControllerTrait
+{
+    /**
+     * Parse the JSON request body, returning null on malformed input and an
+     * empty array on an empty body.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function parseJsonBody(ServerRequestInterface $request): ?array
+    {
+        $rawBody = (string) $request->getBody();
+        if ($rawBody === '') {
+            return [];
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * Create a JSON response carrying the current rate-limit headers.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function jsonResponseWithRateLimitHeaders(
+        array $data,
+        RateLimitResult $rateLimitResult,
+        int $statusCode = 200,
+    ): JsonResponse {
+        $response = new JsonResponse($data, $statusCode);
+
+        foreach ($rateLimitResult->getHeaders() as $name => $value) {
+            $response = $response->withAddedHeader($name, $value);
+        }
+
+        return $response;
+    }
+
+    /**
+     * The standard 429 response for a denied request, including rate-limit and
+     * Retry-After headers.
+     */
+    private function rateLimitedResponse(RateLimitResult $result): JsonResponse
+    {
+        $response = new JsonResponse(
+            ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
+            429,
+        );
+
+        foreach ($result->getHeaders() as $name => $value) {
+            $response = $response->withAddedHeader($name, $value);
+        }
+
+        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
+    }
+}

--- a/Classes/Controller/TemplateController.php
+++ b/Classes/Controller/TemplateController.php
@@ -12,13 +12,11 @@ namespace Netresearch\T3Cowriter\Controller;
 use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
-use Netresearch\T3Cowriter\Service\RateLimitResult;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Http\JsonResponse;
 
 /**
  * AJAX controller for prompt template management.
@@ -29,6 +27,8 @@ use TYPO3\CMS\Core\Http\JsonResponse;
  */
 final readonly class TemplateController
 {
+    use RateLimitedControllerTrait;
+
     public function __construct(
         private TaskRepository $templateRepository,
         private RateLimiterInterface $rateLimiter,
@@ -78,38 +78,5 @@ final readonly class TemplateController
                 500,
             );
         }
-    }
-
-    /**
-     * Create JSON response with rate limit headers.
-     *
-     * @param array<string, mixed> $data
-     */
-    private function jsonResponseWithRateLimitHeaders(
-        array $data,
-        RateLimitResult $rateLimitResult,
-        int $statusCode = 200,
-    ): JsonResponse {
-        $response = new JsonResponse($data, $statusCode);
-
-        foreach ($rateLimitResult->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response;
-    }
-
-    private function rateLimitedResponse(RateLimitResult $result): JsonResponse
-    {
-        $response = new JsonResponse(
-            ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
-            429,
-        );
-
-        foreach ($result->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
     }
 }

--- a/Classes/Controller/ToolController.php
+++ b/Classes/Controller/ToolController.php
@@ -9,20 +9,17 @@ declare(strict_types=1);
 
 namespace Netresearch\T3Cowriter\Controller;
 
-use JsonException;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\T3Cowriter\Domain\DTO\ToolRequest;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
-use Netresearch\T3Cowriter\Service\RateLimitResult;
 use Netresearch\T3Cowriter\Tools\ContentQueryTool;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Http\JsonResponse;
 
 /**
  * AJAX controller for LLM tool calling via nr-llm.
@@ -34,6 +31,8 @@ use TYPO3\CMS\Core\Http\JsonResponse;
  */
 final readonly class ToolController
 {
+    use RateLimitedControllerTrait;
+
     public function __construct(
         private LlmServiceManagerInterface $llmServiceManager,
         private RateLimiterInterface $rateLimiter,
@@ -139,65 +138,5 @@ final readonly class ToolController
         }
 
         return $resolved !== [] ? $resolved : array_values($allTools);
-    }
-
-    /**
-     * Parse JSON body from request, returning null on failure.
-     *
-     * @return array<string, mixed>|null
-     */
-    private function parseJsonBody(ServerRequestInterface $request): ?array
-    {
-        $rawBody = (string) $request->getBody();
-        if ($rawBody === '') {
-            return [];
-        }
-
-        try {
-            /** @var mixed $decoded */
-            $decoded = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return null;
-        }
-
-        if (!is_array($decoded)) {
-            return null;
-        }
-
-        /** @var array<string, mixed> $decoded */
-        return $decoded;
-    }
-
-    /**
-     * Create JSON response with rate limit headers.
-     *
-     * @param array<string, mixed> $data
-     */
-    private function jsonResponseWithRateLimitHeaders(
-        array $data,
-        RateLimitResult $rateLimitResult,
-        int $statusCode = 200,
-    ): JsonResponse {
-        $response = new JsonResponse($data, $statusCode);
-
-        foreach ($rateLimitResult->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response;
-    }
-
-    private function rateLimitedResponse(RateLimitResult $result): JsonResponse
-    {
-        $response = new JsonResponse(
-            ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
-            429,
-        );
-
-        foreach ($result->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
     }
 }

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\T3Cowriter\Controller;
 
-use JsonException;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
@@ -21,14 +20,12 @@ use Netresearch\T3Cowriter\Service\Dto\DiagnosticCheck;
 use Netresearch\T3Cowriter\Service\LlmErrorClassifier;
 use Netresearch\T3Cowriter\Service\LlmErrorKind;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
-use Netresearch\T3Cowriter\Service\RateLimitResult;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Http\JsonResponse;
 
 /**
  * AJAX controller for content translation via nr-llm TranslationService.
@@ -37,6 +34,8 @@ use TYPO3\CMS\Core\Http\JsonResponse;
  */
 final readonly class TranslationController
 {
+    use RateLimitedControllerTrait;
+
     public function __construct(
         private TranslationServiceInterface $translationService,
         private LlmConfigurationRepository $configurationRepository,
@@ -225,65 +224,5 @@ final readonly class TranslationController
     private function isConfigurationError(Throwable $exception): bool
     {
         return $this->errorClassifier->classify($exception) === LlmErrorKind::Configuration;
-    }
-
-    /**
-     * Parse JSON body from request, returning null on failure.
-     *
-     * @return array<string, mixed>|null
-     */
-    private function parseJsonBody(ServerRequestInterface $request): ?array
-    {
-        $rawBody = (string) $request->getBody();
-        if ($rawBody === '') {
-            return [];
-        }
-
-        try {
-            /** @var mixed $decoded */
-            $decoded = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return null;
-        }
-
-        if (!is_array($decoded)) {
-            return null;
-        }
-
-        /** @var array<string, mixed> $decoded */
-        return $decoded;
-    }
-
-    /**
-     * Create JSON response with rate limit headers.
-     *
-     * @param array<string, mixed> $data
-     */
-    private function jsonResponseWithRateLimitHeaders(
-        array $data,
-        RateLimitResult $rateLimitResult,
-        int $statusCode = 200,
-    ): JsonResponse {
-        $response = new JsonResponse($data, $statusCode);
-
-        foreach ($rateLimitResult->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response;
-    }
-
-    private function rateLimitedResponse(RateLimitResult $result): JsonResponse
-    {
-        $response = new JsonResponse(
-            ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
-            429,
-        );
-
-        foreach ($result->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
     }
 }

--- a/Classes/Controller/VisionController.php
+++ b/Classes/Controller/VisionController.php
@@ -9,18 +9,15 @@ declare(strict_types=1);
 
 namespace Netresearch\T3Cowriter\Controller;
 
-use JsonException;
 use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\T3Cowriter\Domain\DTO\VisionRequest;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
-use Netresearch\T3Cowriter\Service\RateLimitResult;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Http\JsonResponse;
 
 /**
  * AJAX controller for image analysis via nr-llm VisionService.
@@ -29,6 +26,8 @@ use TYPO3\CMS\Core\Http\JsonResponse;
  */
 final readonly class VisionController
 {
+    use RateLimitedControllerTrait;
+
     public function __construct(
         private VisionServiceInterface $visionService,
         private RateLimiterInterface $rateLimiter,
@@ -74,7 +73,10 @@ final readonly class VisionController
         }
 
         try {
-            $options  = (new VisionOptions())->withBeUserUid((int) $userId);
+            // altText() preset (detail 'low', maxTokens 100, temperature 0.5)
+            // matches this alt-text endpoint; analyzeImageFull() still returns the
+            // model/confidence/usage metadata the response surfaces.
+            $options  = VisionOptions::altText()->withBeUserUid((int) $userId);
             $response = $this->visionService->analyzeImageFull(
                 $visionRequest->imageUrl,
                 $visionRequest->prompt,
@@ -104,65 +106,5 @@ final readonly class VisionController
                 500,
             );
         }
-    }
-
-    /**
-     * Parse JSON body from request, returning null on failure.
-     *
-     * @return array<string, mixed>|null
-     */
-    private function parseJsonBody(ServerRequestInterface $request): ?array
-    {
-        $rawBody = (string) $request->getBody();
-        if ($rawBody === '') {
-            return [];
-        }
-
-        try {
-            /** @var mixed $decoded */
-            $decoded = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return null;
-        }
-
-        if (!is_array($decoded)) {
-            return null;
-        }
-
-        /** @var array<string, mixed> $decoded */
-        return $decoded;
-    }
-
-    /**
-     * Create JSON response with rate limit headers.
-     *
-     * @param array<string, mixed> $data
-     */
-    private function jsonResponseWithRateLimitHeaders(
-        array $data,
-        RateLimitResult $rateLimitResult,
-        int $statusCode = 200,
-    ): JsonResponse {
-        $response = new JsonResponse($data, $statusCode);
-
-        foreach ($rateLimitResult->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response;
-    }
-
-    private function rateLimitedResponse(RateLimitResult $result): JsonResponse
-    {
-        $response = new JsonResponse(
-            ['success' => false, 'error' => 'Rate limit exceeded. Please try again later.'],
-            429,
-        );
-
-        foreach ($result->getHeaders() as $name => $value) {
-            $response = $response->withAddedHeader($name, $value);
-        }
-
-        return $response->withAddedHeader('Retry-After', (string) $result->getRetryAfter());
     }
 }

--- a/Tests/Unit/Controller/ToolControllerTest.php
+++ b/Tests/Unit/Controller/ToolControllerTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\T3Cowriter\Controller\ToolController;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
@@ -165,6 +166,60 @@ final class ToolControllerTest extends TestCase
 
         $data = json_decode((string) $response->getBody(), true);
         self::assertTrue($data['success']);
+    }
+
+    /**
+     * @param list<string> $requestedTools
+     *
+     * @return list<string> the tool names actually passed to chatWithTools()
+     */
+    private function captureResolvedToolNames(array $requestedTools): array
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $captured = [];
+        $this->llmServiceManagerStub->method('chatWithTools')
+            ->willReturnCallback(function (array $messages, array $tools) use (&$captured): CompletionResponse {
+                $captured = array_map(static fn (ToolSpec $spec): string => $spec->name, $tools);
+
+                return new CompletionResponse(
+                    content: 'ok',
+                    model: 'gpt-4',
+                    usage: new UsageStatistics(1, 1, 2),
+                    finishReason: 'stop',
+                    provider: 'openai',
+                    toolCalls: null,
+                    metadata: null,
+                );
+            });
+
+        $body = ['prompt' => 'Query content'];
+        if ($requestedTools !== []) {
+            $body['tools'] = $requestedTools;
+        }
+
+        $this->subject->executeAction($this->createJsonRequest($body));
+
+        return $captured;
+    }
+
+    #[Test]
+    public function resolveToolsDropsUnknownToolFromMixedList(): void
+    {
+        self::assertSame(['query_content'], $this->captureResolvedToolNames(['query_content', 'bogus_tool']));
+    }
+
+    #[Test]
+    public function resolveToolsFallsBackToAllWhenOnlyInvalidToolsRequested(): void
+    {
+        self::assertSame(['query_content'], $this->captureResolvedToolNames(['bogus_tool']));
+    }
+
+    #[Test]
+    public function resolveToolsResolvesAllWhenNoToolsRequested(): void
+    {
+        self::assertSame(['query_content'], $this->captureResolvedToolNames([]));
     }
 
     #[Test]


### PR DESCRIPTION
Audit follow-ups (batch 1 of 2). Behavior-preserving cleanup + one small preset change + additive tests. The tool-execution feature (#5+#6) follows in a separate PR.

## refactor: shared controller plumbing (#3)

`parseJsonBody()`, `jsonResponseWithRateLimitHeaders()` and `rateLimitedResponse()` were **byte-identical** across the five AJAX controllers — the source of the SonarCloud new-code duplication. Extracted into `RateLimitedControllerTrait`. `AjaxController` keeps its own `rateLimitedResponse()` (it serialises a `CompleteResponse` body); a class method overrides the trait's. Net −79 lines.

## feat: VisionOptions::altText() preset (#7)

The alt-text endpoint used a default `VisionOptions()`; the `altText()` preset (detail `low`, maxTokens 100, temperature 0.5) fits an alt-text endpoint. `analyzeImageFull()` still returns the model/confidence/usage metadata the response surfaces. (Note: caps output at ~100 tokens — appropriate for alt text.)

## test: tool allow-list coverage (#8)

`ToolController::resolveTools()` had no behavioral coverage. Added tests capturing the `ToolSpec` list passed to `chatWithTools()`: unknown name dropped from a mixed list, all-invalid falls back to all tools, no-tools resolves all.

## Not included

- **#9 (translateForConfiguration)** — already fixed on main by #119.
- **#5+#6 (tool execution)** — `query_content` is declared to the model but never executed; routing through `chatWithToolsForConfiguration` + wiring nr-llm's `ToolLoopService` with a `ToolInterface` executor is a larger feature, coming as a separate PR.

## Verification

Full local gate: PHPStan level 10 ✅, unit 605 ✅, integration 30 ✅, e2e 86 ✅, cgl ✅, rector ✅.