### PR TITLE
feat!: require nr-llm ^0.25 and run the tool loop under an explicit actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+## CHANGE
+
+- Require `netresearch/nr-llm ^0.25` (was `^0.23.0`). The tool loop now runs under an explicit actor identity: `ToolLoopServiceInterface::runLoop()` takes a required `ToolExecutionContext` (nr-llm ADR-083), which the tool endpoint derives from the live backend user (`ToolExecutionContext::fromBackendUser()`), falling back to a non-interactive context when no backend user is present. Tools authorise against this context instead of the ambient `$GLOBALS['BE_USER']`, so a queued run authorises identically to a synchronous one.
+
+## MIGRATION
+
+- Upgrade the nr-llm extension to `^0.25` and run `typo3 extension:setup` on the host install (nr-llm adds governance/lease schema).
+- Heads-up: nr-llm's tool data-class gate now defaults to `enforce` on **fresh** installs (ADR-115). Cowriter ships no tools of its own, but the tool loop runs nr-llm's builtin tools, so a builtin whose data class exceeds a configuration's trust zone is withheld under `enforce`. Upgraded installs are pinned to `observe` by nr-llm's `DataClassEnforcementDefaultUpdateWizard` until the operator opts in — run the upgrade wizard after updating.
+
 # 3.3.0 (2026-07-21)
 
 ## ADD

--- a/Classes/Controller/ToolController.php
+++ b/Classes/Controller/ToolController.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Netresearch\T3Cowriter\Domain\DTO\ToolRequest;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
@@ -20,6 +21,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Context\Context;
 
 /**
@@ -108,9 +110,20 @@ final readonly class ToolController
             // enabled set by the loop). Never pass [] — that offers no tools.
             $allowedToolNames = $toolRequest->enabledTools !== [] ? $toolRequest->enabledTools : null;
 
+            // The tool loop must run under an explicit actor identity (nr-llm
+            // ADR-083): tools authorise against it instead of the ambient
+            // $GLOBALS['BE_USER']. This is a backend-authenticated AJAX route,
+            // so derive the context from the live backend user; a missing user
+            // fails closed to a non-interactive context rather than a fatal.
+            $backendUser = $GLOBALS['BE_USER'] ?? null;
+            $context     = $backendUser instanceof BackendUserAuthentication
+                ? ToolExecutionContext::fromBackendUser($backendUser)
+                : ToolExecutionContext::none();
+
             $result = $this->toolLoopService->runLoop(
                 $messages,
                 $configuration,
+                $context,
                 $allowedToolNames,
                 ToolOptions::auto(),
             );

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -7,8 +7,8 @@
 >
     <project
         title="AI Cowriter for TYPO3"
-        version="3.4"
-        release="3.4.1"
+        version="3.5"
+        release="3.5.0"
         copyright="since 2024 by Netresearch DTT GmbH"
     />
 

--- a/Tests/Unit/Controller/ToolControllerTest.php
+++ b/Tests/Unit/Controller/ToolControllerTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Netresearch\T3Cowriter\Controller\ToolController;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
@@ -114,7 +115,7 @@ final class ToolControllerTest extends TestCase
 
         $captured = 'unset';
         $this->toolLoopServiceStub->method('runLoop')
-            ->willReturnCallback(function (array $messages, LlmConfiguration $config, ?array $allowed) use (&$captured): ToolLoopResult {
+            ->willReturnCallback(function (array $messages, LlmConfiguration $config, ToolExecutionContext $context, ?array $allowed) use (&$captured): ToolLoopResult {
                 $captured = $allowed;
 
                 return $this->loopResult('ok');
@@ -135,7 +136,7 @@ final class ToolControllerTest extends TestCase
 
         $captured = 'unset';
         $this->toolLoopServiceStub->method('runLoop')
-            ->willReturnCallback(function (array $messages, LlmConfiguration $config, ?array $allowed) use (&$captured): ToolLoopResult {
+            ->willReturnCallback(function (array $messages, LlmConfiguration $config, ToolExecutionContext $context, ?array $allowed) use (&$captured): ToolLoopResult {
                 $captured = $allowed;
 
                 return $this->loopResult('ok');
@@ -144,6 +145,24 @@ final class ToolControllerTest extends TestCase
         $this->subject->executeAction($this->createJsonRequest(['prompt' => 'Query']));
 
         self::assertNull($captured);
+    }
+
+    #[Test]
+    public function executeActionPassesToolExecutionContextAsThirdArgument(): void
+    {
+        $this->allowRateLimit();
+
+        $captured = null;
+        $this->toolLoopServiceStub->method('runLoop')
+            ->willReturnCallback(function (array $messages, LlmConfiguration $config, ToolExecutionContext $context) use (&$captured): ToolLoopResult {
+                $captured = $context;
+
+                return $this->loopResult('ok');
+            });
+
+        $this->subject->executeAction($this->createJsonRequest(['prompt' => 'Query']));
+
+        self::assertInstanceOf(ToolExecutionContext::class, $captured);
     }
 
     #[Test]

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "typo3/cms-core": "^13.4 || ^14.3",
         "typo3/cms-backend": "^13.4 || ^14.3",
         "typo3/cms-rte-ckeditor": "^13.4 || ^14.3",
-        "netresearch/nr-llm": "^0.23.0"
+        "netresearch/nr-llm": "^0.25"
     },
     "require-dev": {
         "netresearch/typo3-ci-workflows": "^1.3"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,14 +12,14 @@ $EM_CONF[$_EXTKEY] = [
     'author'         => 'Team der Netresearch DTT GmbH',
     'author_email'   => '',
     'author_company' => 'Netresearch DTT GmbH',
-    'version'        => '3.4.1',
+    'version'        => '3.5.0',
     'state'          => 'stable',
     'constraints'    => [
         'depends' => [
             'php'          => '8.2.0-8.9.99',
             'typo3'        => '13.4.0-14.99.99',
             'rte_ckeditor' => '13.4.0-14.99.99',
-            'nr_llm'       => '0.23.0-0.23.99',
+            'nr_llm'       => '0.25.0-0.25.99',
         ],
         'conflicts' => [],
         'suggests'  => [],


### PR DESCRIPTION
## What

Migrate cowriter to `netresearch/nr-llm ^0.25` (was `^0.23.0`).

nr-llm 0.25 (ADR-083) requires the bounded tool loop to run under an **explicit actor identity**. `ToolLoopServiceInterface::runLoop()` gained a required `ToolExecutionContext` as its **third positional argument** (before `$allowedToolNames`), so tools authorise against that context instead of the ambient `$GLOBALS['BE_USER']` — the superglobal is absent on the async queue worker, so this makes a queued run authorise identically to a synchronous one.

Cowriter has exactly **one** broken call site (`Classes/Controller/ToolController.php`). It registers no tools of its own and drives no agent runs, so this is the only code change.

## Verified 0.25 signature

```php
// Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface (v0.25.0, installed)
public function runLoop(
    array $messages,
    LlmConfiguration $configuration,
    ToolExecutionContext $context,   // NEW — required, 3rd positional
    ?array $allowedToolNames,
    ?ToolOptions $options = null,
    // …
): ToolLoopResult;
```

The endpoint is a backend-authenticated AJAX route, so it builds the context from the live backend user, preserving the "act as the current backend user" behaviour; a missing user fails closed to a non-interactive context:

```php
$backendUser = $GLOBALS['BE_USER'] ?? null;
$context     = $backendUser instanceof BackendUserAuthentication
    ? ToolExecutionContext::fromBackendUser($backendUser)
    : ToolExecutionContext::none();

$result = $this->toolLoopService->runLoop($messages, $configuration, $context, $allowedToolNames, ToolOptions::auto());
```

`runLoop()` still returns `ToolLoopResult` (unchanged), so the response mapping (`finalContent`/`iterations`/`truncated`/`usage`) is untouched.

## Changes

- `composer.json`: `netresearch/nr-llm` `^0.23.0` -> `^0.25`
- `ext_emconf.php`: `nr_llm` `0.25.0-0.25.99`; version `3.4.1` -> `3.5.0`
- `Documentation/guides.xml`: `3.5` / `3.5.0`
- `Classes/Controller/ToolController.php`: build `ToolExecutionContext` from the live BE user, pass it as the new 3rd arg
- `Tests/Unit/Controller/ToolControllerTest.php`: thread the context arg through the two `runLoop` closures; add a test asserting a `ToolExecutionContext` is passed as the 3rd argument
- `CHANGELOG.md`: nr-llm ^0.25 bump + data-class-gate `enforce`-by-default heads-up

## Behavioural note (no cowriter code change)

nr-llm's tool data-class gate now defaults to `enforce` on **fresh** installs (ADR-115). Cowriter ships no tools, but the loop runs nr-llm's builtin tools, so a builtin whose data class exceeds a configuration's trust zone is withheld under `enforce`. Upgraded installs are pinned to `observe` by nr-llm's `DataClassEnforcementDefaultUpdateWizard` until the operator opts in — run the upgrade wizard + `typo3 extension:setup` after updating.

## Test evidence (local, PHP 8.5, Docker runner)

- `cgl:fix` — no changes (already clean)
- `phpstan` — **No errors** (level unchanged)
- `unit` — **601 tests, 1597 assertions, OK** (2 pre-existing PHPUnit notices unrelated to this change); `ToolControllerTest` alone: 9 tests / 18 assertions OK
- `functional -d sqlite` — no tests (no DB surface in this consumer)
- `rector` (dry-run) — clean
