### PR TITLE
ci: add gitleaks and zizmor scanners to checks.yml

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,6 +22,20 @@ jobs:
       contents: read
       security-events: write
 
+  gitleaks:
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    permissions:
+      contents: read
+      security-events: write
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  zizmor:
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
   fuzz:
     uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
     permissions:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor (https://zizmor.sh) configuration
+#
+# Tunes zizmor to Netresearch conventions so the audit reports only
+# actionable findings. Third-party actions remain hash-pin enforced.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # First-party reusable workflows track @main by policy and are
+        # never SHA-pinned, so fixes propagate to all consumers.
+        "netresearch/*": ref-pin
+        # Everything else must be pinned to a full commit SHA.
+        "*": hash-pin


### PR DESCRIPTION
Rolls out the `gitleaks` and `zizmor` jobs added to the shared
typo3-extension template in netresearch/.github#327.

- **gitleaks** — secret scanning
- **zizmor** — static analysis for GitHub Actions workflows

Both are report-only (results go to code scanning) and run with minimal
permissions: `contents: read` + `security-events: write`.

The file was byte-identical to the previous template revision before this
change, so the diff is exactly the two new jobs — no repo-specific drift
was touched.
