### PR TITLE
feat(translation): prefer a specialized translator on the quick-translate action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Unreleased
 
+## ADD
+
+- The quick "Translate" toolbar action now prefers a specialized translator
+  (e.g. DeepL) over the generic LLM chat path when one is available and
+  supports the requested language pair. Previously `translateAction()` used
+  `TranslationService::translate()` for the no-configuration case, which
+  never consults the translator registry at all — a configured specialized
+  translator was unreachable from this action unless an editor happened to
+  pin a saved `LlmConfiguration` whose own `translator` field was set.
+  Requires `netresearch/nr-llm`'s `TranslationOptions::withTranslator()`
+  (not yet in a tagged nr-llm release at the time of writing).
+
 ## CHANGE
 
 - Require `netresearch/nr-llm ^0.25` (was `^0.23.0`). The tool loop now runs under an explicit actor identity: `ToolLoopServiceInterface::runLoop()` takes a required `ToolExecutionContext` (nr-llm ADR-083), which the tool endpoint derives from the live backend user (`ToolExecutionContext::fromBackendUser()`), falling back to a non-interactive context when no backend user is present. Tools authorise against this context instead of the ambient `$GLOBALS['BE_USER']`, so a queued run authorises identically to a synchronous one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,16 @@
   Requires `netresearch/nr-llm`'s `TranslationOptions::withTranslator()`
   and `LlmTranslator::IDENTIFIER`, and depends on a fix to
   `DeepLTranslator::supportsLanguagePair()` so it accepts `'auto'` as a
-  source language — none yet in a tagged nr-llm release at the time of
-  writing (netresearch/t3x-nr-llm#571).
+  source language. All three shipped in nr-llm 0.26.0
+  (netresearch/t3x-nr-llm#571).
 
 ## CHANGE
 
-- Require `netresearch/nr-llm ^0.25` (was `^0.23.0`). The tool loop now runs under an explicit actor identity: `ToolLoopServiceInterface::runLoop()` takes a required `ToolExecutionContext` (nr-llm ADR-083), which the tool endpoint derives from the live backend user (`ToolExecutionContext::fromBackendUser()`), falling back to a non-interactive context when no backend user is present. Tools authorise against this context instead of the ambient `$GLOBALS['BE_USER']`, so a queued run authorises identically to a synchronous one.
+- Require `netresearch/nr-llm ^0.26` (was `^0.23.0`). The tool loop now runs under an explicit actor identity: `ToolLoopServiceInterface::runLoop()` takes a required `ToolExecutionContext` (nr-llm ADR-083), which the tool endpoint derives from the live backend user (`ToolExecutionContext::fromBackendUser()`), falling back to a non-interactive context when no backend user is present. Tools authorise against this context instead of the ambient `$GLOBALS['BE_USER']`, so a queued run authorises identically to a synchronous one.
 
 ## MIGRATION
 
-- Upgrade the nr-llm extension to `^0.25` and run `typo3 extension:setup` on the host install (nr-llm adds governance/lease schema).
+- Upgrade the nr-llm extension to `^0.26` and run `typo3 extension:setup` on the host install (nr-llm adds governance/lease schema).
 - Heads-up: nr-llm's tool data-class gate now defaults to `enforce` on **fresh** installs (ADR-115). Cowriter ships no tools of its own, but the tool loop runs nr-llm's builtin tools, so a builtin whose data class exceeds a configuration's trust zone is withheld under `enforce`. Upgraded installs are pinned to `observe` by nr-llm's `DataClassEnforcementDefaultUpdateWizard` until the operator opts in — run the upgrade wizard after updating.
 
 # 3.3.0 (2026-07-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
   translator was unreachable from this action unless an editor happened to
   pin a saved `LlmConfiguration` whose own `translator` field was set.
   Requires `netresearch/nr-llm`'s `TranslationOptions::withTranslator()`
-  (not yet in a tagged nr-llm release at the time of writing).
+  and `LlmTranslator::IDENTIFIER`, and depends on a fix to
+  `DeepLTranslator::supportsLanguagePair()` so it accepts `'auto'` as a
+  source language — none yet in a tagged nr-llm release at the time of
+  writing (netresearch/t3x-nr-llm#571).
 
 ## CHANGE
 

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
+use Netresearch\NrLlm\Specialized\Translation\TranslatorInterface;
 use Netresearch\T3Cowriter\Domain\DTO\TranslationRequest;
 use Netresearch\T3Cowriter\Service\DiagnosticService;
 use Netresearch\T3Cowriter\Service\Dto\DiagnosticCheck;
@@ -94,24 +95,64 @@ final readonly class TranslationController
 
             // When an editor pins a stored configuration, route through the
             // per-configuration path (nr-llm 0.22, #428) so the configuration's
-            // persona/tone, model and provider apply; otherwise use the plain
-            // LLM translation path.
+            // persona/tone, model and provider apply.
             $configuration = $this->resolveConfiguration($translationRequest->configuration);
 
-            $result = $configuration instanceof LlmConfiguration
-                ? $this->translationService->translateForConfiguration(
+            if ($configuration instanceof LlmConfiguration) {
+                $result = $this->translationService->translateForConfiguration(
                     $translationRequest->text,
                     $translationRequest->targetLanguage,
                     $configuration,
                     null,
                     $options,
-                )
-                : $this->translationService->translate(
+                );
+
+                return $this->jsonResponseWithRateLimitHeaders([
+                    'success'        => true,
+                    'translation'    => $result->translation,
+                    'sourceLanguage' => $result->sourceLanguage,
+                    'confidence'     => $result->confidence,
+                    'usage'          => [
+                        'promptTokens'     => $result->usage->promptTokens,
+                        'completionTokens' => $result->usage->completionTokens,
+                        'totalTokens'      => $result->usage->totalTokens,
+                    ],
+                ], $rateLimitResult);
+            }
+
+            // No configuration pinned: prefer a specialized translator (e.g.
+            // DeepL) over the generic LLM path when one is available and
+            // supports this language pair. TranslationService::translate()
+            // never consults the translator registry at all, so a configured
+            // specialized translator was previously unreachable from this
+            // action unless an editor happened to pin a configuration whose
+            // own `translator` field was set — falls back to the plain LLM
+            // translation otherwise, unchanged from before.
+            $bestTranslator = $this->translationService->findBestTranslator('auto', $translationRequest->targetLanguage);
+
+            if ($bestTranslator instanceof TranslatorInterface && $bestTranslator->getIdentifier() !== 'llm') {
+                $specializedResult = $this->translationService->translateWithTranslator(
                     $translationRequest->text,
                     $translationRequest->targetLanguage,
                     null,
-                    $options,
+                    $options->withTranslator($bestTranslator->getIdentifier()),
                 );
+
+                return $this->jsonResponseWithRateLimitHeaders([
+                    'success'        => true,
+                    'translation'    => $specializedResult->translatedText,
+                    'sourceLanguage' => $specializedResult->sourceLanguage,
+                    'confidence'     => $specializedResult->confidence,
+                    'translator'     => $specializedResult->getTranslatorName(),
+                ], $rateLimitResult);
+            }
+
+            $result = $this->translationService->translate(
+                $translationRequest->text,
+                $translationRequest->targetLanguage,
+                null,
+                $options,
+            );
 
             return $this->jsonResponseWithRateLimitHeaders([
                 'success'        => true,

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 namespace Netresearch\T3Cowriter\Controller;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
+use Netresearch\NrLlm\Specialized\Translation\LlmTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorInterface;
 use Netresearch\T3Cowriter\Domain\DTO\TranslationRequest;
 use Netresearch\T3Cowriter\Service\DiagnosticService;
@@ -21,6 +23,7 @@ use Netresearch\T3Cowriter\Service\Dto\DiagnosticCheck;
 use Netresearch\T3Cowriter\Service\LlmErrorClassifier;
 use Netresearch\T3Cowriter\Service\LlmErrorKind;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
+use Netresearch\T3Cowriter\Service\RateLimitResult;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
@@ -107,17 +110,13 @@ final readonly class TranslationController
                     $options,
                 );
 
-                return $this->jsonResponseWithRateLimitHeaders([
-                    'success'        => true,
-                    'translation'    => $result->translation,
-                    'sourceLanguage' => $result->sourceLanguage,
-                    'confidence'     => $result->confidence,
-                    'usage'          => [
-                        'promptTokens'     => $result->usage->promptTokens,
-                        'completionTokens' => $result->usage->completionTokens,
-                        'totalTokens'      => $result->usage->totalTokens,
-                    ],
-                ], $rateLimitResult);
+                return $this->translationResponse(
+                    $result->translation,
+                    $result->sourceLanguage,
+                    $result->confidence,
+                    $rateLimitResult,
+                    usage: $result->usage,
+                );
             }
 
             // No configuration pinned: prefer a specialized translator (e.g.
@@ -130,7 +129,7 @@ final readonly class TranslationController
             // translation otherwise, unchanged from before.
             $bestTranslator = $this->translationService->findBestTranslator('auto', $translationRequest->targetLanguage);
 
-            if ($bestTranslator instanceof TranslatorInterface && $bestTranslator->getIdentifier() !== 'llm') {
+            if ($bestTranslator instanceof TranslatorInterface && $bestTranslator->getIdentifier() !== LlmTranslator::IDENTIFIER) {
                 $specializedResult = $this->translationService->translateWithTranslator(
                     $translationRequest->text,
                     $translationRequest->targetLanguage,
@@ -138,13 +137,13 @@ final readonly class TranslationController
                     $options->withTranslator($bestTranslator->getIdentifier()),
                 );
 
-                return $this->jsonResponseWithRateLimitHeaders([
-                    'success'        => true,
-                    'translation'    => $specializedResult->translatedText,
-                    'sourceLanguage' => $specializedResult->sourceLanguage,
-                    'confidence'     => $specializedResult->confidence,
-                    'translator'     => $specializedResult->getTranslatorName(),
-                ], $rateLimitResult);
+                return $this->translationResponse(
+                    $specializedResult->translatedText,
+                    $specializedResult->sourceLanguage,
+                    $specializedResult->confidence,
+                    $rateLimitResult,
+                    translatorName: $specializedResult->getTranslatorName(),
+                );
             }
 
             $result = $this->translationService->translate(
@@ -154,17 +153,13 @@ final readonly class TranslationController
                 $options,
             );
 
-            return $this->jsonResponseWithRateLimitHeaders([
-                'success'        => true,
-                'translation'    => $result->translation,
-                'sourceLanguage' => $result->sourceLanguage,
-                'confidence'     => $result->confidence,
-                'usage'          => [
-                    'promptTokens'     => $result->usage->promptTokens,
-                    'completionTokens' => $result->usage->completionTokens,
-                    'totalTokens'      => $result->usage->totalTokens,
-                ],
-            ], $rateLimitResult);
+            return $this->translationResponse(
+                $result->translation,
+                $result->sourceLanguage,
+                $result->confidence,
+                $rateLimitResult,
+                usage: $result->usage,
+            );
         } catch (Throwable $e) {
             $this->logger->error('Translation failed', [
                 'exception'      => $e->getMessage(),
@@ -190,6 +185,44 @@ final readonly class TranslationController
                 500,
             );
         }
+    }
+
+    /**
+     * The common shape of a successful translation response. `TranslatorResult`
+     * (specialized path) and `TranslationResult` (LLM path) differ beyond that
+     * common shape — token usage vs. none, translator display name vs. none —
+     * so those two extras are optional and mutually exclusive in practice
+     * (the specialized path never has usage, the LLM path never has a
+     * translator name).
+     */
+    private function translationResponse(
+        string $translation,
+        string $sourceLanguage,
+        ?float $confidence,
+        RateLimitResult $rateLimitResult,
+        ?UsageStatistics $usage = null,
+        ?string $translatorName = null,
+    ): ResponseInterface {
+        $payload = [
+            'success'        => true,
+            'translation'    => $translation,
+            'sourceLanguage' => $sourceLanguage,
+            'confidence'     => $confidence,
+        ];
+
+        if ($usage instanceof UsageStatistics) {
+            $payload['usage'] = [
+                'promptTokens'     => $usage->promptTokens,
+                'completionTokens' => $usage->completionTokens,
+                'totalTokens'      => $usage->totalTokens,
+            ];
+        }
+
+        if ($translatorName !== null) {
+            $payload['translator'] = $translatorName;
+        }
+
+        return $this->jsonResponseWithRateLimitHeaders($payload, $rateLimitResult);
     }
 
     /**

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -9,17 +9,30 @@ declare(strict_types=1);
 
 namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
 
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\TranslationResult;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Feature\TranslationPromptBuilder;
+use Netresearch\NrLlm\Service\Feature\TranslationService;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
+use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
+use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Specialized\Pricing\SpecializedCostCalculatorInterface;
+use Netresearch\NrLlm\Specialized\Translation\DeepLTranslator;
 use Netresearch\NrLlm\Specialized\Translation\LlmTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorInterface;
+use Netresearch\NrLlm\Specialized\Translation\TranslatorRegistry;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\T3Cowriter\Controller\TranslationController;
 use Netresearch\T3Cowriter\Service\DiagnosticService;
 use Netresearch\T3Cowriter\Service\Dto\DiagnosticCheck;
@@ -31,11 +44,18 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\Context;
 
 #[CoversClass(TranslationController::class)]
@@ -96,10 +116,7 @@ final class TranslationControllerTest extends TestCase
         $request  = $this->createJsonRequest(['text' => 'Hello world', 'targetLanguage' => 'de']);
         $response = $this->subject->translateAction($request);
 
-        self::assertSame(200, $response->getStatusCode());
-        $data = json_decode((string) $response->getBody(), true);
-        self::assertTrue($data['success']);
-        self::assertSame('Hallo Welt', $data['translation']);
+        $data = $this->assertSuccessfulTranslationResponse($response, 'Hallo Welt');
         self::assertSame('en', $data['sourceLanguage']);
         self::assertSame(0.9, $data['confidence']);
         self::assertArrayHasKey('usage', $data);
@@ -299,18 +316,7 @@ final class TranslationControllerTest extends TestCase
                 ),
             ]));
 
-        $contextStub = $this->createStub(Context::class);
-        $contextStub->method('getPropertyFromAspect')->willReturn(1);
-
-        $controller = new TranslationController(
-            $this->translationServiceStub,
-            $this->configurationRepositoryStub,
-            $this->rateLimiterStub,
-            $contextStub,
-            new NullLogger(),
-            $this->backendUriBuilderStub,
-            $diagnosticStub,
-        );
+        $controller = $this->createControllerWith($this->translationServiceStub, diagnosticService: $diagnosticStub);
 
         $request  = $this->createJsonRequest(['text' => 'Hello', 'targetLanguage' => 'de']);
         $response = $controller->translateAction($request);
@@ -366,18 +372,7 @@ final class TranslationControllerTest extends TestCase
                 return $translationResult;
             });
 
-        $contextStub = $this->createStub(Context::class);
-        $contextStub->method('getPropertyFromAspect')->willReturn(1);
-
-        $controller = new TranslationController(
-            $translationServiceMock,
-            $configurationRepositoryMock,
-            $this->rateLimiterStub,
-            $contextStub,
-            new NullLogger(),
-            $this->backendUriBuilderStub,
-            $this->diagnosticServiceStub,
-        );
+        $controller = $this->createControllerWith($translationServiceMock, $configurationRepositoryMock);
 
         $request = $this->createJsonRequest([
             'text'           => 'Hello world',
@@ -387,7 +382,7 @@ final class TranslationControllerTest extends TestCase
         ]);
         $response = $controller->translateAction($request);
 
-        self::assertSame(200, $response->getStatusCode());
+        $this->assertSuccessfulTranslationResponse($response, 'Hallo Welt');
         self::assertCount(1, $capturedArgs);
 
         [$text, $targetLang, $config, $sourceLang, $options] = $capturedArgs[0];
@@ -432,18 +427,7 @@ final class TranslationControllerTest extends TestCase
                 return $translationResult;
             });
 
-        $contextStub = $this->createStub(Context::class);
-        $contextStub->method('getPropertyFromAspect')->willReturn(1);
-
-        $controller = new TranslationController(
-            $translationServiceMock,
-            $this->configurationRepositoryStub,
-            $this->rateLimiterStub,
-            $contextStub,
-            new NullLogger(),
-            $this->backendUriBuilderStub,
-            $this->diagnosticServiceStub,
-        );
+        $controller = $this->createControllerWith($translationServiceMock);
 
         $request = $this->createJsonRequest([
             'text'           => 'Hello world',
@@ -452,7 +436,7 @@ final class TranslationControllerTest extends TestCase
         ]);
         $response = $controller->translateAction($request);
 
-        self::assertSame(200, $response->getStatusCode());
+        $this->assertSuccessfulTranslationResponse($response, 'Hallo Welt');
         self::assertCount(1, $capturedArgs);
 
         [$text, $targetLang, $sourceLang, $options] = $capturedArgs[0];
@@ -503,26 +487,12 @@ final class TranslationControllerTest extends TestCase
                 return $translatorResult;
             });
 
-        $contextStub = $this->createStub(Context::class);
-        $contextStub->method('getPropertyFromAspect')->willReturn(1);
-
-        $controller = new TranslationController(
-            $translationServiceMock,
-            $this->configurationRepositoryStub,
-            $this->rateLimiterStub,
-            $contextStub,
-            new NullLogger(),
-            $this->backendUriBuilderStub,
-            $this->diagnosticServiceStub,
-        );
+        $controller = $this->createControllerWith($translationServiceMock);
 
         $request  = $this->createJsonRequest(['text' => 'Hello world', 'targetLanguage' => 'de']);
         $response = $controller->translateAction($request);
 
-        self::assertSame(200, $response->getStatusCode());
-        $data = json_decode((string) $response->getBody(), true);
-        self::assertTrue($data['success']);
-        self::assertSame('Hallo Welt', $data['translation']);
+        $data = $this->assertSuccessfulTranslationResponse($response, 'Hallo Welt');
         self::assertSame('en', $data['sourceLanguage']);
         self::assertSame(0.95, $data['confidence']);
         self::assertSame('Deepl', $data['translator']);
@@ -561,27 +531,50 @@ final class TranslationControllerTest extends TestCase
             ->method('translate')
             ->willReturn($translationResult);
 
-        $contextStub = $this->createStub(Context::class);
-        $contextStub->method('getPropertyFromAspect')->willReturn(1);
-
-        $controller = new TranslationController(
-            $translationServiceMock,
-            $this->configurationRepositoryStub,
-            $this->rateLimiterStub,
-            $contextStub,
-            new NullLogger(),
-            $this->backendUriBuilderStub,
-            $this->diagnosticServiceStub,
-        );
+        $controller = $this->createControllerWith($translationServiceMock);
 
         $request  = $this->createJsonRequest(['text' => 'Hello world', 'targetLanguage' => 'de']);
         $response = $controller->translateAction($request);
 
-        self::assertSame(200, $response->getStatusCode());
-        $data = json_decode((string) $response->getBody(), true);
-        self::assertTrue($data['success']);
-        self::assertSame('Hallo Welt', $data['translation']);
+        $data = $this->assertSuccessfulTranslationResponse($response, 'Hallo Welt');
         self::assertArrayHasKey('usage', $data);
+    }
+
+    /**
+     * Functional-lite: every other test in this class stubs
+     * TranslationServiceInterface directly, which only proves the
+     * controller reacts correctly to whatever TranslationService returns —
+     * it can never catch a regression in the actual selection chain
+     * (registry priority ordering, DeepLTranslator::supportsLanguagePair()).
+     * This wires the REAL TranslationService + TranslatorRegistry +
+     * DeepLTranslator + LlmTranslator; only the outermost HTTP transport is
+     * faked, via DeepLTranslator::setHttpClient() (the same test seam
+     * netresearch/t3x-nr-llm's own DeepLTranslatorTest uses).
+     */
+    #[Test]
+    public function translateActionRoutesThroughARealTranslatorRegistryToDeepL(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $translationService = $this->createRealTranslationServiceDispatchingDeeplTo(
+            $this->createJsonResponseMock(['translations' => [
+                ['text' => 'Hallo Welt', 'detected_source_language' => 'EN'],
+            ]]),
+        );
+
+        $controller = $this->createControllerWith($translationService);
+
+        $request  = $this->createJsonRequest(['text' => 'Hello world', 'targetLanguage' => 'de']);
+        $response = $controller->translateAction($request);
+
+        $data = $this->assertSuccessfulTranslationResponse($response, 'Hallo Welt');
+        self::assertSame(
+            'Deepl',
+            $data['translator'],
+            'the real TranslatorRegistry must select DeepLTranslator over the LlmTranslator fallback for an "auto"->"de" pair',
+        );
+        self::assertSame('en', $data['sourceLanguage']);
     }
 
     #[Test]
@@ -602,18 +595,7 @@ final class TranslationControllerTest extends TestCase
         $translationServiceMock->expects(self::never())->method('translateForConfiguration');
         $translationServiceMock->expects(self::never())->method('translate');
 
-        $contextStub = $this->createStub(Context::class);
-        $contextStub->method('getPropertyFromAspect')->willReturn(1);
-
-        $controller = new TranslationController(
-            $translationServiceMock,
-            $configurationRepositoryMock,
-            $this->rateLimiterStub,
-            $contextStub,
-            new NullLogger(),
-            $this->backendUriBuilderStub,
-            $this->diagnosticServiceStub,
-        );
+        $controller = $this->createControllerWith($translationServiceMock, $configurationRepositoryMock);
 
         $request = $this->createJsonRequest([
             'text'           => 'Hello world',
@@ -628,6 +610,166 @@ final class TranslationControllerTest extends TestCase
         self::assertNotSame('', $data['error']);
         // Classified as a configuration error, so the status-page link is offered.
         self::assertArrayHasKey('statusUrl', $data);
+    }
+
+    /**
+     * Build a TranslationController wired to a real (aspect-stubbed) Context
+     * and the shared rate-limiter/backend-URI-builder stubs, swapping in only
+     * the translation service (and, for the handful of tests that need it,
+     * the configuration repository / diagnostic service). Every action test
+     * needs this same wiring; only the service under observation differs.
+     */
+    private function createControllerWith(
+        TranslationServiceInterface $translationService,
+        ?LlmConfigurationRepository $configurationRepository = null,
+        ?DiagnosticService $diagnosticService = null,
+    ): TranslationController {
+        $contextStub = $this->createStub(Context::class);
+        $contextStub->method('getPropertyFromAspect')->willReturn(1);
+
+        return new TranslationController(
+            $translationService,
+            $configurationRepository ?? $this->configurationRepositoryStub,
+            $this->rateLimiterStub,
+            $contextStub,
+            new NullLogger(),
+            $this->backendUriBuilderStub,
+            $diagnosticService ?? $this->diagnosticServiceStub,
+        );
+    }
+
+    /**
+     * Assert the response-shape tail every success-path test starts with
+     * (HTTP 200, decoded JSON, success=true, the translated text), and hand
+     * back the decoded body so the caller can assert on the fields that
+     * actually differ between paths (sourceLanguage/confidence/usage/
+     * translator — TranslationResult and TranslatorResult don't carry the
+     * same shape, see translateActionPrefersSpecializedTranslatorWhenAvailable
+     * vs. translateActionReturnsTranslation).
+     *
+     * @return array<string, mixed>
+     */
+    private function assertSuccessfulTranslationResponse(ResponseInterface $response, string $expectedTranslation): array
+    {
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertTrue($data['success']);
+        self::assertSame($expectedTranslation, $data['translation']);
+
+        return $data;
+    }
+
+    /**
+     * Build a real TranslationService wired to a real TranslatorRegistry
+     * containing a real DeepLTranslator (configured + available, HTTP
+     * transport replaced by a stub returning $deeplResponse) and a real
+     * LlmTranslator (available, but never reachable in these tests since
+     * DeepL's supportsLanguagePair('auto', 'de') wins the registry scan
+     * first — registry array order here mirrors DeepLTranslator's real
+     * getPriority()=90 sorting ahead of LlmTranslator's getPriority()=-1000).
+     */
+    private function createRealTranslationServiceDispatchingDeeplTo(ResponseInterface $deeplResponse): TranslationServiceInterface
+    {
+        $vaultStub = $this->createStub(VaultServiceInterface::class);
+        $vaultStub->method('retrieve')->willReturn('test-secret');
+        $vaultStub->method('exists')->willReturn(true);
+
+        $deeplHttpClientStub = $this->createStub(ClientInterface::class);
+        $deeplHttpClientStub->method('sendRequest')->willReturn($deeplResponse);
+
+        $extensionConfigurationStub = $this->createStub(ExtensionConfiguration::class);
+        $extensionConfigurationStub->method('get')->willReturn([
+            'translators' => [
+                'deepl' => ['apiKeyIdentifier' => 'deepl-test-key', 'timeout' => 30],
+            ],
+        ]);
+
+        $budgetServiceStub = $this->createStub(BudgetServiceInterface::class);
+        $budgetServiceStub->method('check')->willReturn(BudgetCheckResult::allowed());
+
+        $deeplTranslator = new DeepLTranslator(
+            $vaultStub,
+            $this->createBareRequestFactory(),
+            $this->createBareStreamFactory(),
+            $extensionConfigurationStub,
+            $this->createStub(UsageTrackerServiceInterface::class),
+            new NullLogger(),
+            $this->createStub(SpecializedCostCalculatorInterface::class),
+            $budgetServiceStub,
+            new MiddlewarePipeline([]),
+            new InputGuardrailScreener([]),
+        );
+        $deeplTranslator->setHttpClient($deeplHttpClientStub);
+
+        $llmManagerStub = $this->createStub(LlmServiceManagerInterface::class);
+        $llmManagerStub->method('hasAvailableProvider')->willReturn(true);
+        $llmTranslator = new LlmTranslator($llmManagerStub, $this->createStub(UsageTrackerServiceInterface::class));
+
+        $registry = new TranslatorRegistry([$deeplTranslator, $llmTranslator]);
+
+        return new TranslationService(
+            $llmManagerStub,
+            $registry,
+            $this->createStub(LlmConfigurationServiceInterface::class),
+            new TranslationPromptBuilder(),
+        );
+    }
+
+    private function createBareRequestFactory(): RequestFactoryInterface
+    {
+        $stub = $this->createStub(RequestFactoryInterface::class);
+        $stub->method('createRequest')->willReturnCallback(
+            fn (string $method, string $uri): RequestInterface => $this->createBareRequest($method, $uri),
+        );
+
+        return $stub;
+    }
+
+    private function createBareRequest(string $method, string $uri): RequestInterface
+    {
+        $uriStub = $this->createStub(UriInterface::class);
+        $uriStub->method('__toString')->willReturn($uri);
+
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('withHeader')->willReturnCallback(fn (): RequestInterface => $request);
+        $request->method('withBody')->willReturnCallback(fn (): RequestInterface => $request);
+        $request->method('withoutHeader')->willReturnCallback(fn (): RequestInterface => $request);
+        $request->method('getMethod')->willReturn($method);
+        $request->method('getUri')->willReturn($uriStub);
+
+        return $request;
+    }
+
+    private function createBareStreamFactory(): StreamFactoryInterface
+    {
+        $stub = $this->createStub(StreamFactoryInterface::class);
+        $stub->method('createStream')->willReturnCallback(function (string $content): StreamInterface {
+            $stream = $this->createStub(StreamInterface::class);
+            $stream->method('__toString')->willReturn($content);
+            $stream->method('getContents')->willReturn($content);
+
+            return $stream;
+        });
+
+        return $stub;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function createJsonResponseMock(array $data, int $statusCode = 200): ResponseInterface
+    {
+        $body = json_encode($data, JSON_THROW_ON_ERROR);
+
+        $stream = $this->createStub(StreamInterface::class);
+        $stream->method('__toString')->willReturn($body);
+        $stream->method('getContents')->willReturn($body);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($statusCode);
+        $response->method('getBody')->willReturn($stream);
+
+        return $response;
     }
 
     /**

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -17,6 +17,8 @@ use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
+use Netresearch\NrLlm\Specialized\Translation\TranslatorInterface;
+use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
 use Netresearch\T3Cowriter\Controller\TranslationController;
 use Netresearch\T3Cowriter\Service\DiagnosticService;
 use Netresearch\T3Cowriter\Service\Dto\DiagnosticCheck;
@@ -458,6 +460,127 @@ final class TranslationControllerTest extends TestCase
         self::assertNull($sourceLang, 'sourceLanguage must be null, not the configuration value');
         self::assertInstanceOf(TranslationOptions::class, $options);
         self::assertSame('formal', $options->getFormality());
+    }
+
+    #[Test]
+    public function translateActionPrefersSpecializedTranslatorWhenAvailable(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $deeplTranslator = $this->createStub(TranslatorInterface::class);
+        $deeplTranslator->method('getIdentifier')->willReturn('deepl');
+
+        $translatorResult = new TranslatorResult(
+            translatedText: 'Hallo Welt',
+            sourceLanguage: 'en',
+            targetLanguage: 'de',
+            translator: 'deepl',
+            confidence: 0.95,
+        );
+
+        /** @var list<array{string, string, ?string, ?TranslationOptions}> */
+        $capturedArgs = [];
+
+        $translationServiceMock = $this->createMock(TranslationServiceInterface::class);
+        $translationServiceMock->expects(self::never())->method('translateForConfiguration');
+        $translationServiceMock->expects(self::never())->method('translate');
+        $translationServiceMock->expects(self::once())
+            ->method('findBestTranslator')
+            ->with('auto', 'de')
+            ->willReturn($deeplTranslator);
+        $translationServiceMock->expects(self::once())
+            ->method('translateWithTranslator')
+            ->willReturnCallback(static function (
+                string $text,
+                string $targetLanguage,
+                ?string $sourceLanguage,
+                ?TranslationOptions $options,
+            ) use (&$capturedArgs, $translatorResult): TranslatorResult {
+                $capturedArgs[] = [$text, $targetLanguage, $sourceLanguage, $options];
+
+                return $translatorResult;
+            });
+
+        $contextStub = $this->createStub(Context::class);
+        $contextStub->method('getPropertyFromAspect')->willReturn(1);
+
+        $controller = new TranslationController(
+            $translationServiceMock,
+            $this->configurationRepositoryStub,
+            $this->rateLimiterStub,
+            $contextStub,
+            new NullLogger(),
+            $this->backendUriBuilderStub,
+            $this->diagnosticServiceStub,
+        );
+
+        $request  = $this->createJsonRequest(['text' => 'Hello world', 'targetLanguage' => 'de']);
+        $response = $controller->translateAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertTrue($data['success']);
+        self::assertSame('Hallo Welt', $data['translation']);
+        self::assertSame('en', $data['sourceLanguage']);
+        self::assertSame(0.95, $data['confidence']);
+        self::assertSame('Deepl', $data['translator']);
+        self::assertArrayNotHasKey('usage', $data, 'TranslatorResult carries no token usage, unlike TranslationResult');
+
+        self::assertCount(1, $capturedArgs);
+        [$text, $targetLang, $sourceLang, $options] = $capturedArgs[0];
+        self::assertSame('Hello world', $text);
+        self::assertSame('de', $targetLang);
+        self::assertNull($sourceLang);
+        self::assertInstanceOf(TranslationOptions::class, $options);
+        self::assertSame('deepl', $options->getTranslator());
+    }
+
+    #[Test]
+    public function translateActionUsesPlainLlmPathWhenBestTranslatorIsTheLlmFallbackItself(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $llmTranslator = $this->createStub(TranslatorInterface::class);
+        $llmTranslator->method('getIdentifier')->willReturn('llm');
+
+        $translationResult = new TranslationResult(
+            translation: 'Hallo Welt',
+            sourceLanguage: 'en',
+            targetLanguage: 'de',
+            confidence: 0.9,
+            usage: new UsageStatistics(50, 30, 80),
+        );
+
+        $translationServiceMock = $this->createMock(TranslationServiceInterface::class);
+        $translationServiceMock->method('findBestTranslator')->willReturn($llmTranslator);
+        $translationServiceMock->expects(self::never())->method('translateWithTranslator');
+        $translationServiceMock->expects(self::once())
+            ->method('translate')
+            ->willReturn($translationResult);
+
+        $contextStub = $this->createStub(Context::class);
+        $contextStub->method('getPropertyFromAspect')->willReturn(1);
+
+        $controller = new TranslationController(
+            $translationServiceMock,
+            $this->configurationRepositoryStub,
+            $this->rateLimiterStub,
+            $contextStub,
+            new NullLogger(),
+            $this->backendUriBuilderStub,
+            $this->diagnosticServiceStub,
+        );
+
+        $request  = $this->createJsonRequest(['text' => 'Hello world', 'targetLanguage' => 'de']);
+        $response = $controller->translateAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertTrue($data['success']);
+        self::assertSame('Hallo Welt', $data['translation']);
+        self::assertArrayHasKey('usage', $data);
     }
 
     #[Test]

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Feature\TranslationServiceInterface;
 use Netresearch\NrLlm\Service\Option\TranslationOptions;
+use Netresearch\NrLlm\Specialized\Translation\LlmTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorInterface;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
 use Netresearch\T3Cowriter\Controller\TranslationController;
@@ -543,7 +544,7 @@ final class TranslationControllerTest extends TestCase
             ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
 
         $llmTranslator = $this->createStub(TranslatorInterface::class);
-        $llmTranslator->method('getIdentifier')->willReturn('llm');
+        $llmTranslator->method('getIdentifier')->willReturn(LlmTranslator::IDENTIFIER);
 
         $translationResult = new TranslationResult(
             translation: 'Hallo Welt',


### PR DESCRIPTION
Fixes #133.

## What

`translateAction()`'s no-configuration branch used `TranslationService::translate()`, which never consults nr-llm's translator registry — a specialized translator (DeepL) was unreachable from the toolbar's quick "Translate" dropdown regardless of configuration, since that button never pins an `LlmConfiguration`. See #133 for the full trace.

Now, when no configuration is pinned, the action calls `TranslationService::findBestTranslator('auto', $targetLanguage)` first; if it resolves to a specialized translator (anything other than the `'llm'` fallback identifier), the request goes through `translateWithTranslator()` with that translator explicitly selected. Falls back to the previous plain LLM path otherwise — unchanged behavior when no specialized translator is configured/available.

`TranslatorResult` (specialized path) and `TranslationResult` (LLM path) are different DTOs (`translatedText` vs `translation`, no token usage vs `usage`), so the response is built inline per branch rather than through the shared tail of the try block.

## Dependency

This depends on `netresearch/nr-llm`'s `TranslationOptions::withTranslator()`, proposed in netresearch/t3x-nr-llm#571 (not yet in a tagged release) — needed so `findBestTranslator()`'s result can be forwarded to `translateWithTranslator()` without pinning an entire `LlmConfiguration` just to reach the explicit-translator branch of `resolveTranslator()`. That PR also fixes a priority-ordering bug (#570) that currently makes `findBestTranslator()` return the LLM fallback even when DeepL is available — without it, this PR's new branch would never actually trigger in practice.

`composer.json`'s `netresearch/nr-llm` constraint is left untouched here (still `^0.25`) — bumping it is a release-flow concern for the maintainers once #571 ships, not something I want to do from a feature PR.

## Testing

Tested locally against a `composer.json` VCS-repository override pointing `netresearch/nr-llm` at the `fix/translator-registry-priority-and-explicit-selection` branch (reverted before this commit — not part of the diff). With that in place:

- Full unit suite: 603 tests, 0 failures.
- `Build/phpstan.neon` (project config + baseline): no errors.
- CGL (`.php-cs-fixer.dist.php`): clean, nothing to fix.

Added two tests to `TranslationControllerTest`:
- `translateActionPrefersSpecializedTranslatorWhenAvailable` — asserts `translateWithTranslator()` is called with the resolved translator's identifier, `translate()`/`translateForConfiguration()` are never called, and the response is shaped from `TranslatorResult` (`translator` key present, no `usage` key).
- `translateActionUsesPlainLlmPathWhenBestTranslatorIsTheLlmFallbackItself` — asserts the plain `translate()` path (and `TranslationResult` response shape) is still used when `findBestTranslator()` resolves to the `'llm'` identifier itself.

## Note on commit signing

No GPG key configured in this environment — commit is DCO-signed off (`--signoff`) but not GPG-signed (`-S`). Happy to re-sign or let a maintainer cherry-pick if required for merge.