### PR TITLE
Only turn http(s) URLs into the setup-status link

### DIFF
--- a/Resources/Public/JavaScript/Ckeditor/CowriterDialog.js
+++ b/Resources/Public/JavaScript/Ckeditor/CowriterDialog.js
@@ -932,9 +932,28 @@ export class CowriterDialog {
      * @param {string} instructionSent - The instruction that was sent
      * @private
      */
+    /**
+     * Only http(s) URLs become a link.
+     *
+     * One caller passes `error.statusUrl` out of a catch block, so the value can
+     * originate in an API response rather than in our own code. Assigned to
+     * `href` unchecked, a `javascript:` or `data:` scheme there executes on
+     * click — which is what CodeQL's js/xss-through-exception reports. The
+     * status module is an ordinary backend URL, so anything that is not http(s)
+     * is not a status link and the caller gets no link at all.
+     */
+    _isHttpUrl(candidate) {
+        try {
+            const { protocol } = new URL(candidate, globalThis.location.origin);
+            return protocol === 'http:' || protocol === 'https:';
+        } catch {
+            return false;
+        }
+    }
+
     _appendStatusLink(container, statusUrl) {
         const url = statusUrl || this._service.getModuleUrl('statusModule');
-        if (!url) {
+        if (!url || !this._isHttpUrl(url)) {
             return;
         }
         const link = document.createElement('a');

--- a/Tests/JavaScript/CowriterDialog.test.js
+++ b/Tests/JavaScript/CowriterDialog.test.js
@@ -1901,6 +1901,67 @@ describe('CowriterDialog', () => {
         });
     });
 
+    describe('_appendStatusLink URL scheme guard', () => {
+        let dialog;
+        let container;
+
+        beforeEach(() => {
+            dialog = new CowriterDialog(mockService);
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+
+        it.each([
+            ['javascript:alert(1)'],
+            ['data:text/html,<script>alert(1)</script>'],
+            ['vbscript:msgbox(1)'],
+        ])('should not link a %s URL', (hostileUrl) => {
+            dialog._appendStatusLink(container, hostileUrl);
+
+            expect(container.querySelector('a')).toBeNull();
+        });
+
+        it('should link an absolute https URL', () => {
+            dialog._appendStatusLink(container, 'https://example.org/status');
+
+            const link = container.querySelector('a');
+            expect(link).not.toBeNull();
+            expect(link.getAttribute('href')).toBe('https://example.org/status');
+            expect(link.getAttribute('target')).toBe('_blank');
+            expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+        });
+
+        it('should link a site-relative URL, which resolves against the page origin', () => {
+            dialog._appendStatusLink(container, '/typo3/module/cowriter/status');
+
+            expect(container.querySelector('a')?.getAttribute('href'))
+                .toBe('/typo3/module/cowriter/status');
+        });
+
+        it('should fall back to the status module route when no URL is passed', () => {
+            mockService._routes = { statusModule: '/typo3/module/cowriter/status' };
+
+            dialog._appendStatusLink(container, undefined);
+
+            expect(container.querySelector('a')?.getAttribute('href'))
+                .toBe('/typo3/module/cowriter/status');
+        });
+
+        it('should append nothing when neither a URL nor a route is available', () => {
+            dialog._appendStatusLink(container, '');
+
+            expect(container.querySelector('a')).toBeNull();
+        });
+
+        it('should reject a hostile scheme coming from the fallback route', () => {
+            mockService._routes = { statusModule: 'javascript:alert(1)' };
+
+            dialog._appendStatusLink(container, null);
+
+            expect(container.querySelector('a')).toBeNull();
+        });
+    });
+
     describe('modal hidden event (Escape/X close)', () => {
         it('should reject promise and abort requests when typo3-modal-hidden fires', async () => {
             const dialog = new CowriterDialog(mockService);


### PR DESCRIPTION
Closes `js/xss-through-exception` (MEDIUM), live on `main` at `CowriterDialog.js:941`. It surfaced when JavaScript analysis was restored across the fleet ([netresearch/.github#348](https://github.com/netresearch/.github/pull/348)); the code is not new.

## The flow

The sink is the `href` assignment in `_appendStatusLink()`:

```js
const url = statusUrl || this._service.getModuleUrl('statusModule');
const link = document.createElement('a');
link.href = url;
```

It has two callers, and the second is what makes the rule's premise hold:

| line | call |
|---|---|
| 314 | `this._appendStatusLink(preview, result.statusUrl)` — from an API result |
| 332 | `this._appendStatusLink(preview, error.statusUrl)` — **inside a catch block** |

`error.statusUrl` is a property carried on a caught exception, so its value can originate in an API response rather than in our own code. Assigned to `href` unchecked, a `javascript:` or `data:` scheme executes when the editor clicks the link.

## The fix

`_isHttpUrl()` resolves the candidate against the current origin and admits only `http:` and `https:`. Nothing legitimate is excluded — the status module is an ordinary backend URL:

| input | verdict |
|---|---|
| `/typo3/module/status` | allowed (relative, resolves same-origin) |
| `https://example.test/x` | allowed |
| `javascript:alert(1)` | blocked |
| `data:text/html,<script>…` | blocked |
| `vbscript:msgbox` | blocked |

Measured by running the predicate against those inputs, not reasoned about.

The guard sits inside `_appendStatusLink` rather than at the two call sites, so both the result path and the error path are covered once. An empty value still short-circuits on the existing `!url` check.
