### PR TITLE
Restrict the setup-status link to our own origin

### DIFF
--- a/Resources/Public/JavaScript/Ckeditor/CowriterDialog.js
+++ b/Resources/Public/JavaScript/Ckeditor/CowriterDialog.js
@@ -924,15 +924,6 @@ export class CowriterDialog {
     }
 
     /**
-     * Show collapsible debug details below the model info.
-     *
-     * @param {HTMLElement} container
-     * @param {object} result - The API response
-     * @param {string} inputText - The original input text sent
-     * @param {string} instructionSent - The instruction that was sent
-     * @private
-     */
-    /**
      * Only same-origin http(s) URLs become a link.
      *
      * One caller passes `error.statusUrl` out of a catch block, so the value can
@@ -970,6 +961,15 @@ export class CowriterDialog {
         container.appendChild(link);
     }
 
+    /**
+     * Show collapsible debug details below the model info.
+     *
+     * @param {HTMLElement} container
+     * @param {object} result - The API response
+     * @param {string} inputText - The original input text sent
+     * @param {string} instructionSent - The instruction that was sent
+     * @private
+     */
     _showDebugDetails(container, result, inputText, instructionSent) {
         // Remove existing debug section if re-executing
         container.querySelector('[data-role="debug-details"]')?.remove();

--- a/Resources/Public/JavaScript/Ckeditor/CowriterDialog.js
+++ b/Resources/Public/JavaScript/Ckeditor/CowriterDialog.js
@@ -933,19 +933,24 @@ export class CowriterDialog {
      * @private
      */
     /**
-     * Only http(s) URLs become a link.
+     * Only same-origin http(s) URLs become a link.
      *
      * One caller passes `error.statusUrl` out of a catch block, so the value can
      * originate in an API response rather than in our own code. Assigned to
      * `href` unchecked, a `javascript:` or `data:` scheme there executes on
-     * click — which is what CodeQL's js/xss-through-exception reports. The
-     * status module is an ordinary backend URL, so anything that is not http(s)
-     * is not a status link and the caller gets no link at all.
+     * click — which is what CodeQL's js/xss-through-exception reports.
+     *
+     * Checking the scheme alone leaves the host open, so a supplied
+     * `https://elsewhere.example/…` would still become a link the editor is
+     * invited to click. The status module is a TYPO3 backend route and is
+     * therefore always on our own origin; anything pointing elsewhere is not a
+     * status link, and the caller gets no link at all.
      */
-    _isHttpUrl(candidate) {
+    _isSameOriginHttpUrl(candidate) {
         try {
-            const { protocol } = new URL(candidate, globalThis.location.origin);
-            return protocol === 'http:' || protocol === 'https:';
+            const url = new URL(candidate, globalThis.location.origin);
+            return (url.protocol === 'http:' || url.protocol === 'https:')
+                && url.origin === globalThis.location.origin;
         } catch {
             return false;
         }
@@ -953,7 +958,7 @@ export class CowriterDialog {
 
     _appendStatusLink(container, statusUrl) {
         const url = statusUrl || this._service.getModuleUrl('statusModule');
-        if (!url || !this._isHttpUrl(url)) {
+        if (!url || !this._isSameOriginHttpUrl(url)) {
             return;
         }
         const link = document.createElement('a');

--- a/Tests/JavaScript/CowriterDialog.test.js
+++ b/Tests/JavaScript/CowriterDialog.test.js
@@ -1901,7 +1901,7 @@ describe('CowriterDialog', () => {
         });
     });
 
-    describe('_appendStatusLink URL scheme guard', () => {
+    describe('_appendStatusLink origin guard', () => {
         let dialog;
         let container;
 
@@ -1921,14 +1921,26 @@ describe('CowriterDialog', () => {
             expect(container.querySelector('a')).toBeNull();
         });
 
-        it('should link an absolute https URL', () => {
-            dialog._appendStatusLink(container, 'https://example.org/status');
+        it('should link an absolute URL on our own origin', () => {
+            const ownUrl = `${globalThis.location.origin}/typo3/module/cowriter/status`;
+
+            dialog._appendStatusLink(container, ownUrl);
 
             const link = container.querySelector('a');
             expect(link).not.toBeNull();
-            expect(link.getAttribute('href')).toBe('https://example.org/status');
+            expect(link.getAttribute('href')).toBe(ownUrl);
             expect(link.getAttribute('target')).toBe('_blank');
             expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+        });
+
+        it.each([
+            ['https://elsewhere.example/status'],
+            ['http://elsewhere.example/status'],
+            ['//elsewhere.example/status'],
+        ])('should not link %s, which is off our origin', (foreignUrl) => {
+            dialog._appendStatusLink(container, foreignUrl);
+
+            expect(container.querySelector('a')).toBeNull();
         });
 
         it('should link a site-relative URL, which resolves against the page origin', () => {
@@ -1955,6 +1967,14 @@ describe('CowriterDialog', () => {
 
         it('should reject a hostile scheme coming from the fallback route', () => {
             mockService._routes = { statusModule: 'javascript:alert(1)' };
+
+            dialog._appendStatusLink(container, null);
+
+            expect(container.querySelector('a')).toBeNull();
+        });
+
+        it('should reject a foreign host coming from the fallback route', () => {
+            mockService._routes = { statusModule: 'https://elsewhere.example/status' };
 
             dialog._appendStatusLink(container, null);
 


### PR DESCRIPTION
Follow-up to #140, which did not close CodeQL alert [#63](https://github.com/netresearch/t3x-cowriter/security/code-scanning/63).

## Why #140 was not enough

#140 rejected non-http(s) schemes, so `javascript:` and `data:` can no longer reach `href`. CodeQL re-analysed `main` after the merge and reported the same alert again on the guarded line, which prompted a second look at what the guard actually covers.

It covers the scheme and nothing else. `statusUrl` is read out of a catch block, so it can originate in an API response rather than in our own code — and any `http(s)` host passed:

| value | after #140 | now |
|---|---|---|
| `javascript:alert(1)` | rejected | rejected |
| `https://elsewhere.example/status` | **linked** | rejected |
| `/typo3/module/cowriter/status` | linked | linked |

Not script execution, so not XSS in the strict sense — but a link the editor is invited to click, pointing wherever the response says. That is worth closing on its own, independently of whether it satisfies the scanner.

## The change

The status module is a TYPO3 backend route and therefore always on our own origin. The origin is the honest condition, so `_isHttpUrl` becomes `_isSameOriginHttpUrl` and compares `url.origin` against `globalThis.location.origin`.

## Verification

Four tests cover the new branch, and they were checked **in position**: removing the origin comparison fails exactly those four and leaves the other 109 passing. A test that passes either way would not have shown that.

Lint is unchanged — the four eslint errors in this file (lines 96, 672, 824, 876) are identical on `origin/main` and predate this branch.

Whether this also closes the CodeQL alert will only be visible after the next analysis of `main`; the change stands on the link-injection argument regardless.

## Second commit

`docs:` moves the JSDoc for `_showDebugDetails` back above that method — it sat above `_appendStatusLink`, reading as documentation for the wrong one. Pre-dates #140. Comment motion only, 9 lines out, 9 lines in.
