### PR TITLE
chore(deps): require nr-llm ^0.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ AI-powered content assistant for TYPO3 CKEditor - write better content with help
 
 - PHP 8.2+
 - TYPO3 v13.4 LTS or v14.3 LTS
-- [netresearch/nr-llm](https://github.com/netresearch/t3x-nr-llm) 0.22+ (LLM provider abstraction)
+- [netresearch/nr-llm](https://github.com/netresearch/t3x-nr-llm) 0.26+ (LLM provider abstraction)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "typo3/cms-core": "^13.4 || ^14.3",
         "typo3/cms-backend": "^13.4 || ^14.3",
         "typo3/cms-rte-ckeditor": "^13.4 || ^14.3",
-        "netresearch/nr-llm": "^0.25"
+        "netresearch/nr-llm": "^0.26"
     },
     "require-dev": {
         "netresearch/typo3-ci-workflows": "^1.3"


### PR DESCRIPTION
Moves the nr-llm floor to [`^0.26.0`](https://github.com/netresearch/t3x-nr-llm/releases/tag/v0.26.0).

All 26 `Netresearch\\NrLlm\\*` symbols this extension references resolve against 0.26 unchanged. The release's only removals — `CapabilityPermissionService` and its interface — are not used here.

Also corrects the README, which named nr-llm `0.22+` against a `^0.25` constraint.