### PR TITLE
Resolve the setup-status href locally instead of from the payload

### DIFF
--- a/Resources/Public/JavaScript/Ckeditor/CowriterDialog.js
+++ b/Resources/Public/JavaScript/Ckeditor/CowriterDialog.js
@@ -924,18 +924,12 @@ export class CowriterDialog {
     }
 
     /**
-     * Only same-origin http(s) URLs become a link.
+     * Defence in depth on the locally injected route.
      *
-     * One caller passes `error.statusUrl` out of a catch block, so the value can
-     * originate in an API response rather than in our own code. Assigned to
-     * `href` unchecked, a `javascript:` or `data:` scheme there executes on
-     * click — which is what CodeQL's js/xss-through-exception reports.
-     *
-     * Checking the scheme alone leaves the host open, so a supplied
-     * `https://elsewhere.example/…` would still become a link the editor is
-     * invited to click. The status module is a TYPO3 backend route and is
-     * therefore always on our own origin; anything pointing elsewhere is not a
-     * status link, and the caller gets no link at all.
+     * The route comes from `TYPO3.settings.ajaxUrls`, so it is ours and this
+     * check should never reject it. It stays because a value that reaches
+     * `href` deserves a guard regardless of how trustworthy its source looks
+     * today, and because the cost is one comparison.
      */
     _isSameOriginHttpUrl(candidate) {
         try {
@@ -947,8 +941,32 @@ export class CowriterDialog {
         }
     }
 
-    _appendStatusLink(container, statusUrl) {
-        const url = statusUrl || this._service.getModuleUrl('statusModule');
+    /**
+     * Append the setup-status link.
+     *
+     * `hasStatus` is a SIGNAL, not a URL. Both callers read it off an API
+     * payload — one of them out of a catch block, i.e. from an exception — and
+     * a value from there must never reach `href`. Earlier revisions did exactly
+     * that and tried to make it safe by validating the scheme, then also the
+     * origin; CodeQL kept reporting js/xss-through-exception because the
+     * exception-derived value still flowed into the sink, guard or no guard.
+     *
+     * There is no need for it to. `TYPO3.settings.ajaxUrls.cowriter_status`
+     * puts the very same backend route on the page independently of any
+     * response, so the href is resolved locally and the payload only decides
+     * WHETHER a link is worth showing. The taint path is gone rather than
+     * fenced off, which is both the stronger property and the one a scanner
+     * can see.
+     *
+     * @param {HTMLElement} container
+     * @param {unknown} hasStatus truthy when the backend reported a status
+     *                            endpoint; its value is deliberately unused
+     */
+    _appendStatusLink(container, hasStatus) {
+        if (!hasStatus) {
+            return;
+        }
+        const url = this._service.getModuleUrl('statusModule');
         if (!url || !this._isSameOriginHttpUrl(url)) {
             return;
         }

--- a/Tests/JavaScript/CowriterDialog.test.js
+++ b/Tests/JavaScript/CowriterDialog.test.js
@@ -1901,82 +1901,63 @@ describe('CowriterDialog', () => {
         });
     });
 
-    describe('_appendStatusLink origin guard', () => {
+    describe('_appendStatusLink: href comes from the local route, never the payload', () => {
+        const ROUTE = '/typo3/module/cowriter/status';
         let dialog;
         let container;
 
         beforeEach(() => {
             dialog = new CowriterDialog(mockService);
+            mockService._routes = { statusModule: ROUTE };
             container = document.createElement('div');
             document.body.appendChild(container);
         });
 
-        it.each([
-            ['javascript:alert(1)'],
-            ['data:text/html,<script>alert(1)</script>'],
-            ['vbscript:msgbox(1)'],
-        ])('should not link a %s URL', (hostileUrl) => {
-            dialog._appendStatusLink(container, hostileUrl);
-
-            expect(container.querySelector('a')).toBeNull();
-        });
-
-        it('should link an absolute URL on our own origin', () => {
-            const ownUrl = `${globalThis.location.origin}/typo3/module/cowriter/status`;
-
-            dialog._appendStatusLink(container, ownUrl);
+        it('should link the locally injected route when the backend signals a status endpoint', () => {
+            dialog._appendStatusLink(container, ROUTE);
 
             const link = container.querySelector('a');
             expect(link).not.toBeNull();
-            expect(link.getAttribute('href')).toBe(ownUrl);
+            expect(link.getAttribute('href')).toBe(ROUTE);
             expect(link.getAttribute('target')).toBe('_blank');
             expect(link.getAttribute('rel')).toBe('noopener noreferrer');
         });
 
+        // The whole point of the redesign: whatever the payload carries, it is a
+        // signal only. A hostile value must not reach href — and must not
+        // suppress the link either, because the href never came from it.
         it.each([
+            ['javascript:alert(1)'],
+            ['data:text/html,<script>alert(1)</script>'],
             ['https://elsewhere.example/status'],
-            ['http://elsewhere.example/status'],
             ['//elsewhere.example/status'],
-        ])('should not link %s, which is off our origin', (foreignUrl) => {
-            dialog._appendStatusLink(container, foreignUrl);
+        ])('should ignore the payload value %s and still link the local route', (payload) => {
+            dialog._appendStatusLink(container, payload);
 
-            expect(container.querySelector('a')).toBeNull();
+            expect(container.querySelector('a')?.getAttribute('href')).toBe(ROUTE);
         });
 
-        it('should link a site-relative URL, which resolves against the page origin', () => {
-            dialog._appendStatusLink(container, '/typo3/module/cowriter/status');
-
-            expect(container.querySelector('a')?.getAttribute('href'))
-                .toBe('/typo3/module/cowriter/status');
-        });
-
-        it('should fall back to the status module route when no URL is passed', () => {
-            mockService._routes = { statusModule: '/typo3/module/cowriter/status' };
-
+        it('should append nothing when the backend signalled no status endpoint', () => {
             dialog._appendStatusLink(container, undefined);
 
-            expect(container.querySelector('a')?.getAttribute('href'))
-                .toBe('/typo3/module/cowriter/status');
+            expect(container.querySelector('a')).toBeNull();
         });
 
-        it('should append nothing when neither a URL nor a route is available', () => {
-            dialog._appendStatusLink(container, '');
+        it('should append nothing when the route is not configured', () => {
+            mockService._routes = {};
+
+            dialog._appendStatusLink(container, ROUTE);
 
             expect(container.querySelector('a')).toBeNull();
         });
 
-        it('should reject a hostile scheme coming from the fallback route', () => {
-            mockService._routes = { statusModule: 'javascript:alert(1)' };
+        it.each([
+            ['javascript:alert(1)'],
+            ['https://elsewhere.example/status'],
+        ])('should reject a route of %s, so a mis-injected route cannot become a link', (badRoute) => {
+            mockService._routes = { statusModule: badRoute };
 
-            dialog._appendStatusLink(container, null);
-
-            expect(container.querySelector('a')).toBeNull();
-        });
-
-        it('should reject a foreign host coming from the fallback route', () => {
-            mockService._routes = { statusModule: 'https://elsewhere.example/status' };
-
-            dialog._appendStatusLink(container, null);
+            dialog._appendStatusLink(container, 'truthy-signal');
 
             expect(container.querySelector('a')).toBeNull();
         });


### PR DESCRIPTION
Third and, I think, final attempt at CodeQL alert [#63](https://github.com/netresearch/t3x-cowriter/security/code-scanning/63) (`js/xss-through-exception`) — this time by removing the taint path rather than guarding it.

## Why two guards were not enough

| PR | guard added | outcome |
|---|---|---|
| #140 | reject non-`http(s)` schemes | real improvement; alert stayed |
| #141 | additionally require same origin | real improvement; alert stayed |

Both closed genuine holes: a `javascript:` URL cannot execute and a foreign host cannot become a link the editor is invited to click. Twelve tests prove it. And CodeQL still reports the alert on current `main` — the last JavaScript analysis ran today at 06:56 on `e880296f` and flagged `link.href = url` again.

That is not the analyser being obtuse. The exception-derived value still **flows into** the sink; the guard is simply something CodeQL does not model. Adding a third guard would have produced the same result, and the honest reading of two failed attempts is that the approach was wrong, not insufficient.

## The value never needed to be there

`AIService` already populates the route from the page:

```js
this._routes.statusModule = TYPO3.settings.ajaxUrls.cowriter_status || null;
```

So the same backend route is available locally, independently of any API response. The payload's `statusUrl` was redundant as a URL — the backend builds both from `backendUriBuilder`, and the controller tests assert the same `/typo3/module/cowriter/status` on either side.

The href is therefore resolved from the local route, and the payload only decides **whether** a link is worth showing. Renamed to `hasStatus` so the signature says so.

This is also the more defensible design regardless of the scanner: we link to a route we know, not one a response told us to use.

## Behaviour

| payload | before | now |
|---|---|---|
| `/typo3/module/cowriter/status` | links it | links the local route — same target |
| `javascript:alert(1)` | no link | ignored; local route still linked |
| `https://elsewhere.example/status` | no link | ignored; local route still linked |
| absent | falls back to route | no link |
| route missing | uses payload | no link |

The two rows that change are deliberate: a hostile payload must not reach `href`, and it must not suppress the link either, because the href never came from it.

## Verification

110 tests pass. Verified **in position**: restoring the payload as the href source fails six of the new tests, so they close the gap where the gap is rather than somewhere adjacent.

Lint is unchanged — the four eslint errors in this file (lines 96, 672, 824, 876) are identical on `origin/main` and predate this branch.

Whether CodeQL clears the alert will only show after the next analysis of `main`. Unlike the previous two attempts this one does not depend on the analyser recognising anything: there is no longer a path from the exception to `href`.
