### PR TITLE
build(deps): require nr-llm ^0.28

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "typo3/cms-core": "^13.4 || ^14.3",
         "typo3/cms-backend": "^13.4 || ^14.3",
         "typo3/cms-rte-ckeditor": "^13.4 || ^14.3",
-        "netresearch/nr-llm": "^0.26"
+        "netresearch/nr-llm": "^0.28"
     },
     "require-dev": {
         "netresearch/typo3-ci-workflows": "^1.3"


### PR DESCRIPTION
The cap at `^0.26` did not even admit **0.27** — caret on a `0.x` version excludes the next minor — so this package held the dependency tree two minors back and blocked the TYPO3 demo from reaching nr-vault 0.15, which it needs to provision its OpenAI key from the deploy.

## Verified against the resolved 0.28.0

`Locking netresearch/nr-llm (v0.28.0)`, `netresearch/nr-vault (v0.15.0)`:

| Check | Result |
|---|---|
| unit | 604 tests, 1627 assertions |
| functional | SUCCESS |

0.27's one consumer-visible change is `ToolCallPolicy`, which no longer takes an optional `ExtensionConfiguration` and requires a resolver. Nothing here constructs it.

## PHPStan is left to CI, and why I am not quoting a local number

Locally it will not load its config: `ergebnis/phpstan-rules` does not register through `phpstan/extension-installer` in a container-based resolve, so the run dies on `Unexpected item 'parameters › ergebnis'`.

Running it on `main` instead looks tempting and is worse. That `.Build` holds **nr-llm v0.25.0** while `composer.json` already declares `^0.26` — the directory predates the last bump. Its three findings in `TranslationController.php` (undefined constant, undefined method, wrong `$options` parameter) measure a version this package no longer claims to support, so they say nothing about 0.28 either way.

Two numbers, neither of them a baseline. CI resolves from the declared constraint on a clean checkout, so its PHPStan run is the one worth reading — and if those three findings are real drift rather than an artefact of a stale directory, this PR is exactly where they should surface.
