### PR TITLE
chore(release): 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Unreleased
 
+# 3.6.2 (2026-08-13)
+
+## CHANGE
+
+- Accepts `netresearch/nr-llm` `^0.29` alongside `^0.28`, so this extension can
+  be installed next to one that needs 0.29. Nothing here touches the three
+  surfaces 0.29 broke: `ModelSelectionServiceInterface` is consumed, never
+  implemented, and neither `ContextFitResult` nor `InputSubmission` is
+  constructed.
+
+## FIX
+
+- `ext_emconf.php` demanded nr_llm `0.25.0-0.25.99`, which excluded the `^0.28`
+  composer.json has required since 3.6.1. The two constraints now say the same
+  thing.
+
 # 3.6.1 (2026-08-10)
 
 ## CHANGE

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -8,7 +8,7 @@
     <project
         title="AI Cowriter for TYPO3"
         version="3.6"
-        release="3.6.1"
+        release="3.6.2"
         copyright="since 2024 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "typo3/cms-core": "^13.4 || ^14.3",
         "typo3/cms-backend": "^13.4 || ^14.3",
         "typo3/cms-rte-ckeditor": "^13.4 || ^14.3",
-        "netresearch/nr-llm": "^0.28"
+        "netresearch/nr-llm": "^0.28 || ^0.29"
     },
     "require-dev": {
         "netresearch/typo3-ci-workflows": "^1.3"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,14 +12,14 @@ $EM_CONF[$_EXTKEY] = [
     'author'         => 'Team der Netresearch DTT GmbH',
     'author_email'   => '',
     'author_company' => 'Netresearch DTT GmbH',
-    'version'        => '3.6.1',
+    'version'        => '3.6.2',
     'state'          => 'stable',
     'constraints'    => [
         'depends' => [
             'php'          => '8.2.0-8.9.99',
             'typo3'        => '13.4.0-14.99.99',
             'rte_ckeditor' => '13.4.0-14.99.99',
-            'nr_llm'       => '0.25.0-0.25.99',
+            'nr_llm'       => '0.28.0-0.29.99',
         ],
         'conflicts' => [],
         'suggests'  => [],


### PR DESCRIPTION
Accepts nr-llm 0.29 alongside 0.28, so this extension can be installed next to one that needs 0.29. Patch, like [3.6.1](https://github.com/netresearch/t3x-cowriter/releases/tag/v3.6.1), which raised the same constraint: nothing here changes behaviour or this extension's own API.

## Why it is safe

nr-llm [v0.29.0](https://github.com/netresearch/t3x-nr-llm/releases/tag/v0.29.0) broke three surfaces. Checked against each rather than assumed:

| Surface | How it broke | Here |
|---|---|---|
| `ModelSelectionServiceInterface` | gained `resolveModelForCall()`; an implementation outside nr-llm must add it | not referenced |
| `ContextFitResult` | constructor gained a required ninth argument | never constructed |
| `InputSubmission` | constructor takes the turn digest; a caller omitting it has every submission refused | never constructed |

## A second constraint that disagreed

`ext_emconf.php` demanded nr_llm `0.25.0-0.25.99`. That excludes the `^0.28` composer.json has required since 3.6.1 — so a TER installation would have refused what composer installs, and the release that moved composer forward left this one behind. Both now read `0.28.0-0.29.99`.

## Evidence

Against nr-llm 0.29.1, `runTests.sh -p 8.4`: `unit`, `functional`, `phpstan` (No errors) and `cgl` all SUCCESS.