### PR TITLE
docs: option 1 described a mechanism the extension does not register

### DIFF
--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -52,9 +52,9 @@ this extension registers:
 2.  Open :guilabel:`Page Properties` > :guilabel:`Page TSconfig`
 3.  Add this line:
 
-..  code-block:: typoscript
+    ..  code-block:: typoscript
 
-    RTE.default.preset = cowriter
+        RTE.default.preset = cowriter
 
 The preset is inherited by every page below, and brings all four toolbar
 items with it.

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -42,14 +42,22 @@ RTE configuration
 
 There are two ways to configure the CKEditor integration:
 
-Option 1: Using static PageTSconfig
------------------------------------
+Option 1: Using the shipped preset
+----------------------------------
 
-If you don't have a custom RTE configuration, include the static PageTSconfig:
+If you don't have a custom RTE configuration, point the RTE at the preset
+this extension registers:
 
 1.  Go to your root page
-2.  Open :guilabel:`Page Properties` > :guilabel:`Resources`
-3.  Add the static PageTSconfig from :guilabel:`t3_cowriter`
+2.  Open :guilabel:`Page Properties` > :guilabel:`Page TSconfig`
+3.  Add this line:
+
+..  code-block:: typoscript
+
+    RTE.default.preset = cowriter
+
+The preset is inherited by every page below, and brings all four toolbar
+items with it.
 
 ..  figure:: /Images/pagetsconfig.png
     :alt: Page TSconfig configuration in TYPO3 v14
@@ -95,6 +103,14 @@ The four toolbar items are:
     You can include only the toolbar items you need. For example, if you
     only want the main dialog and translation, omit ``cowriterVision``
     and ``cowriterTemplates``.
+
+..  warning::
+
+    An explicit ``toolbar.items`` list REPLACES the toolbar, it does not add
+    to it. Importing the module and then listing only ``cowriter`` gives you
+    exactly one button — the other three are registered but have nowhere to
+    appear. If buttons are missing, check this list before suspecting the
+    extension.
 
 Task configuration
 ==================


### PR DESCRIPTION
Closes #148.

`Documentation/Configuration/Index.rst` told the reader to enable the preset through :guilabel:`Page Properties` > :guilabel:`Resources` and "add the static PageTSconfig from t3_cowriter". There is nothing to select there — the extension never calls `ExtensionManagementUtility::registerPageTSConfigFile()`. What `Configuration/TCA/Overrides/sys_template.php` registers is static *TypoScript*, a different field, and `Configuration/TypoScript/setup.typoscript` is intentionally empty.

The figure caption three lines further down already described the way that works, and `README.md` (Option A) documents it too. The steps now match both.

Second change, from the same investigation (#149's sibling): a **warning** that an explicit `toolbar.items` list *replaces* the toolbar rather than adding to it. A consuming site imported the Cowriter module, listed only `cowriter` in its own preset, and reported the other three components as missing from the extension — they were registered the whole time with nowhere to appear. That is the first thing to check when buttons do not show up.