### PR TITLE
fix(ci): unblock the repository — php-cs-fixer 3.95.19 alignment and the harden-runner pin

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -126,7 +126,7 @@ jobs:
     permissions: {}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 

--- a/Classes/EventListener/InjectAjaxUrlsListener.php
+++ b/Classes/EventListener/InjectAjaxUrlsListener.php
@@ -43,7 +43,7 @@ final readonly class InjectAjaxUrlsListener
             $event->getAssetCollector()->addInlineJavaScript(
                 'cowriter-ajax-urls-data',
                 $this->buildJsonData(),
-                ['type'     => 'application/json', 'id' => 'cowriter-ajax-urls-data'],
+                ['type' => 'application/json', 'id' => 'cowriter-ajax-urls-data'],
                 ['priority' => true],
             );
 
@@ -51,7 +51,7 @@ final readonly class InjectAjaxUrlsListener
             $event->getAssetCollector()->addJavaScript(
                 'cowriter-url-loader',
                 'EXT:t3_cowriter/Resources/Public/JavaScript/Ckeditor/UrlLoader.js',
-                ['type'     => 'module'],
+                ['type' => 'module'],
                 ['priority' => true],
             );
         } catch (JsonException|RouteNotFoundException $e) {

--- a/Tests/Unit/EventListener/InjectAjaxUrlsListenerTest.php
+++ b/Tests/Unit/EventListener/InjectAjaxUrlsListenerTest.php
@@ -69,7 +69,7 @@ final class InjectAjaxUrlsListenerTest extends TestCase
             ->with(
                 'cowriter-ajax-urls-data',
                 $this->isString(),
-                ['type'     => 'application/json', 'id' => 'cowriter-ajax-urls-data'],
+                ['type' => 'application/json', 'id' => 'cowriter-ajax-urls-data'],
                 ['priority' => true],
             );
 
@@ -79,7 +79,7 @@ final class InjectAjaxUrlsListenerTest extends TestCase
             ->with(
                 'cowriter-url-loader',
                 'EXT:t3_cowriter/Resources/Public/JavaScript/Ckeditor/UrlLoader.js',
-                ['type'     => 'module'],
+                ['type' => 'module'],
                 ['priority' => true],
             );
 


### PR DESCRIPTION
Two changes that could not land separately, because they blocked each other.

## The code style failure

`ci / Code Style` is failing on every pull request in this repository, and the cause is not in the tree. `main` at `9e4c092a` passed it on 17 August at 06:14. `friendsofphp/php-cs-fixer` released **v3.95.19** later that day. The same commit failed on 18 August at 06:05, on four single-line array literals whose keys were padded to align:

```
-                ['type'     => 'application/json', 'id' => 'cowriter-ajax-urls-data'],
+                ['type' => 'application/json', 'id' => 'cowriter-ajax-urls-data'],
```

Two occurrences in `InjectAjaxUrlsListener.php` and the two matching ones in its test. Whitespace inside array literals — no behaviour, no logic. The test file has to move with the production one because it compares the literal byte for byte.

## The harden-runner pin, folded in from #152

The shared template moved to harden-runner v2.21.0 in netresearch/.github#380, so this repository's v2.20.1 now fails `drift / Template drift`.

#152 carries exactly that one-line bump, and the two pull requests deadlocked: #152 could not merge because `Code Style` was red, and this one could not merge because `drift` was red for the pin #152 fixes. Folding the line in here breaks the cycle with one merge instead of two. #152 becomes redundant and gets closed as superseded, pointing here.

Same SHA #152 proposed, checked against `step-security/harden-runner`'s own `v2.21.0` tag ref rather than taken from the comment beside it.

## Verification

`checks.yml` is now identical to the template's — confirmed with the comparator `netresearch/.github` ships rather than by eye: `drift_compare.py`'s parse-and-compare says the documents are equal, and they are byte-equal too. So `drift` goes green rather than merely becoming non-blocking.

The style change was **not verified locally** — this worktree has no `.Build`, so there is no php-cs-fixer here to run. It is the diff the failing job printed, applied verbatim; both files pass `php -l`; and CI is the check that was failing. `ci / Code Style` and `ci / All CI checks` went green on the first push.

Closes #152
