### PR TITLE
docs(agents): sync AGENTS.md files and adopt agent-harness verification

### DIFF
--- a/.github/workflows/harness-verify.yml
+++ b/.github/workflows/harness-verify.yml
@@ -1,0 +1,23 @@
+name: Harness Verification
+
+# Verifies agent-harness consistency (AGENTS.md line budget, dead references,
+# documented commands vs composer.json/Makefile, docs/ structure) via
+# Build/Scripts/verify-harness.sh. Thin caller of the shared script-check
+# reusable, so the checkout pin and harden-runner are maintained centrally.
+# Exit 2 means warnings only and passes; exit 1 (errors) fails the check.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  harness-verify:
+    uses: netresearch/.github/.github/workflows/script-check.yml@main
+    permissions:
+      contents: read
+    with:
+      check-cmd: bash Build/Scripts/verify-harness.sh || [ $? -eq 2 ]

--- a/.gitignore
+++ b/.gitignore
@@ -44,9 +44,6 @@ Documentation-GENERATED-temp/
 # Playwright
 /blob-report/
 
-# Planning docs
-docs/
-
 # direnv
 .env
 .envrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,411 +1,100 @@
-# AI Agent Development Guide
+<!-- FOR AI AGENTS - Human readability is a side effect, not a goal -->
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
 
-**Project:** t3_cowriter - AI-powered content writing assistant for TYPO3 CKEditor
-**Last Updated:** 2026-03-15
-**Type:** TYPO3 CMS Extension (PHP 8.2+ / JavaScript/ES6)
-**TYPO3:** 13.4 LTS + 14.3
-**License:** GPL-3.0-or-later
+# AGENTS.md
 
-## Quick Start
+**Precedence:** The **closest AGENTS.md** to changed files wins. Root holds global defaults only.
 
-```bash
-# Install dependencies
-composer install
+## Project Overview
 
-# Development workflow
-composer ci:test             # Run all linters + static analysis
-composer ci:test:all         # Run all tests (unit, integration, e2e)
-composer ci:cgl              # Fix code style
-composer ci:rector           # Apply PHP modernization
+AI-powered content writing assistant for the TYPO3 CKEditor 5 RTE. Adds toolbar actions for chat/completion, vision (image alt text), translation, prompt templates, and LLM tool calling. All LLM traffic goes through the PHP backend via `netresearch/nr-llm` — never directly from the browser.
 
-# Local TYPO3 instance (optional, for manual testing only)
-make up                      # Start DDEV + install TYPO3 v14
-make urls                    # Show access URLs
-```
-
-## Setup
-
-### Prerequisites
-
-- **PHP:** 8.2+ (CI tests 8.2, 8.3, 8.4, 8.5) with extensions: dom, libxml
-- **Composer:** Latest stable
-- **TYPO3:** 13.4 LTS or 14.3+
-- **DDEV:** For local development
-- **Docker:** For DDEV and docs rendering
-
-### Installation
-
-```bash
-# Clone and start
-git clone https://github.com/netresearch/t3x-cowriter.git
-cd t3x-cowriter
-make up                      # Start DDEV + install all
-
-# Or manually
-ddev start
-ddev install-v14
-```
+- **Package**: `netresearch/t3-cowriter` (Composer) / `t3_cowriter` (TER extension key)
+- **Namespace**: `Netresearch\T3Cowriter\`
+- **Tech Stack**: PHP ^8.2, TYPO3 ^13.4 || ^14.3, CKEditor 5, JavaScript ES modules
+- **License**: GPL-3.0-or-later; version: see [ext_emconf.php](ext_emconf.php) (do not pin versions here)
+- **Key dependency**: `netresearch/nr-llm` (LLM abstraction, provides `LlmServiceManagerInterface`)
 
 ## Architecture
 
-### Supported Version Matrix
+Component map, AJAX route table, and data flow: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
-| TYPO3 | PHP | Status |
-|-------|-----|--------|
-| 13.4 LTS | 8.2, 8.3, 8.4, 8.5 | Supported |
-| 14.3 | 8.2, 8.3, 8.4, 8.5 | Supported |
+Short form: CKEditor plugin (`Resources/Public/JavaScript/Ckeditor/`) → 12 backend AJAX routes ([Configuration/Backend/AjaxRoutes.php](Configuration/Backend/AjaxRoutes.php)) → controllers in `Classes/Controller/` → `LlmServiceManagerInterface` (nr-llm) → provider API. A backend status module (`cowriter_status`) surfaces `DiagnosticService` results for setup troubleshooting.
 
-### Component Overview
-
-```
-t3_cowriter/
-├── Classes/
-│   ├── Controller/
-│   │   ├── AjaxController.php       # Main chat/complete/stream endpoints
-│   │   ├── Backend/
-│   │   │   └── StatusController.php # Setup status diagnostic page
-│   │   ├── VisionController.php     # Image analysis (alt text)
-│   │   ├── TranslationController.php # Content translation
-│   │   ├── TemplateController.php   # Prompt template listing
-│   │   └── ToolController.php       # LLM function calling
-│   ├── Domain/DTO/                  # Request/response DTOs
-│   ├── Service/
-│   │   ├── DiagnosticService.php    # 8-step LLM config chain checker
-│   │   ├── Dto/                     # Severity, DiagnosticCheck, DiagnosticResult
-│   │   ├── ContextAssemblyService.php # Context building for tasks
-│   │   ├── RateLimiterInterface.php # Rate limiter abstraction
-│   │   └── RateLimiterService.php   # Sliding window rate limiter
-│   └── Tools/ContentQueryTool.php   # Tool definition for TYPO3 queries
-├── Configuration/
-│   ├── Backend/
-│   │   ├── AjaxRoutes.php           # 11 AJAX route definitions
-│   │   └── Modules.php              # Backend module registration (cowriter_status)
-│   ├── RTE/Cowriter.yaml            # CKEditor toolbar configuration
-│   └── Services.yaml                # DI container
-├── Resources/Public/JavaScript/Ckeditor/
-│   ├── AIService.js                 # Frontend API client (all endpoints + AIServiceError)
-│   ├── cowriter.js                  # CKEditor plugin (4 toolbar items)
-│   ├── CowriterDialog.js            # Task dialog UI (incl. status link on errors)
-│   └── UrlLoader.js                 # CSP-compliant URL injection
-└── Documentation/                   # RST documentation
-```
-
-### Data Flow
-
-```
-CKEditor Toolbar
-  ├─ cowriter         → CowriterDialog → AIService.js → AjaxController
-  ├─ cowriterVision   → AIService.js ─────────────────→ VisionController
-  ├─ cowriterTranslate→ AIService.js ─────────────────→ TranslationController
-  ├─ cowriterTemplates→ AIService.js ─────────────────→ TemplateController
-  └─ (tool calling)   → AIService.js ─────────────────→ ToolController
-                                                              ↓
-                                                   LlmServiceManagerInterface
-                                                              ↓
-                                                        nr-llm Provider → AI API
-```
-
-### AJAX Routes
-
-| Route | Path | Controller | Purpose |
-|-------|------|------------|---------|
-| `tx_cowriter_chat` | `/cowriter/chat` | `AjaxController::chatAction` | Chat completion (stateless) |
-| `tx_cowriter_complete` | `/cowriter/complete` | `AjaxController::completeAction` | Single prompt completion |
-| `tx_cowriter_stream` | `/cowriter/stream` | `AjaxController::streamAction` | Streaming via SSE |
-| `tx_cowriter_configurations` | `/cowriter/configurations` | `AjaxController::getConfigurationsAction` | List LLM configurations |
-| `tx_cowriter_tasks` | `/cowriter/tasks` | `AjaxController::getTasksAction` | List available tasks |
-| `tx_cowriter_task_execute` | `/cowriter/task-execute` | `AjaxController::executeTaskAction` | Execute a task |
-| `tx_cowriter_context` | `/cowriter/context` | `AjaxController::getContextAction` | Context preview |
-| `tx_cowriter_vision` | `/cowriter/vision` | `VisionController::analyzeAction` | Image alt text generation |
-| `tx_cowriter_translate` | `/cowriter/translate` | `TranslationController::translateAction` | Content translation |
-| `tx_cowriter_templates` | `/cowriter/templates` | `TemplateController::listAction` | Prompt template listing |
-| `tx_cowriter_tools` | `/cowriter/tools` | `ToolController::executeAction` | LLM tool/function calling |
-
-### Key Dependencies
-
-- **netresearch/nr-llm:** Backend LLM abstraction layer
-- **typo3/cms-rte-ckeditor:** CKEditor 5 integration
-
-## Build & Test Commands
-
-**CI is authoritative** - always verify fixes pass in GitHub Actions CI before merging.
-Run tests locally via composer (same as CI), not via DDEV.
-
-CI runs a **multi-version matrix**: PHP 8.2, 8.3, 8.4, 8.5 x TYPO3 ^13.4, ^14.3.
-See `.github/workflows/ci.yml` for the full matrix definition.
-
-### Quality Checks
+## Commands
 
 ```bash
-composer ci:test:php:lint    # PHP syntax check
-composer ci:test:php:phpstan # Static analysis (level 10)
+composer install             # Install dependencies (vendor dir: .Build/vendor)
+
+# Quality checks (same as CI)
+composer ci:test             # lint + phpstan + rector + cgl
+composer ci:test:php:lint    # PHP syntax check (phplint)
+composer ci:test:php:phpstan # PHPStan (Build/phpstan.neon)
+composer ci:test:php:rector  # Rector dry-run
 composer ci:test:php:cgl     # Code style check
-composer ci:test:php:rector  # PHP modernization check
-composer ci:test             # All of the above
-```
-
-### Tests
-
-```bash
-composer ci:test:php:unit        # Unit tests
-composer ci:test:php:integration # Integration tests
-composer ci:test:php:e2e         # E2E tests
-composer ci:test:all             # All tests
-```
-
-### Code Fixes
-
-```bash
 composer ci:cgl              # Auto-fix code style
-composer ci:rector           # Apply PHP modernization
+composer ci:rector           # Apply Rector
+
+# PHP tests (Docker-based via Build/Scripts/runTests.sh)
+composer ci:test:php:unit        # Unit tests
+composer ci:test:php:functional  # Functional tests
+composer ci:test:php:integration # Integration tests
+composer ci:test:php:e2e         # E2E tests (PHP)
+composer ci:test:all             # unit + functional + integration + e2e
+
+# JavaScript
+npm run lint                 # ESLint on Resources/Public/JavaScript
+npm test                     # Vitest unit tests (Tests/JavaScript/)
+npm run test:e2e             # Playwright E2E specs (Tests/E2E/)
+
+# Local TYPO3 instance (DDEV, manual testing only)
+make up                      # Start DDEV + install TYPO3 v13/v14 + render docs + pull Ollama model
+make urls                    # Show access URLs
 ```
 
-### Individual Commands
-
-```bash
-# PHP Linting
-composer ci:test:php:lint
-
-# Static Analysis
-composer ci:test:php:phpstan
-
-# Code Style Check
-composer ci:test:php:cgl
-
-# Code Style Fix
-composer ci:cgl
-
-# Rector (PHP Modernization)
-composer ci:test:php:rector
-composer ci:rector                  # Apply changes
-```
+**CI is authoritative** — verify fixes pass in GitHub Actions before merging. The matrix (PHP 8.2–8.5 × TYPO3 ^13.4/^14.3) runs via the shared reusable workflows in `netresearch/typo3-ci-workflows`.
 
 ## CI/CD Workflows
 
-All workflows are in `.github/workflows/`. Key workflows:
+All files in `.github/workflows/` are thin callers of `netresearch/typo3-ci-workflows` and `netresearch/.github` reusables:
 
-| Workflow | File | Purpose |
-|----------|------|---------|
-| **CI** | `ci.yml` | Multi-version matrix: PHP 8.2-8.5 x TYPO3 v13.4/v14.3 (lint, phpstan, unit, functional, integration, e2e tests) |
-| **PR Quality Gates** | `pr-quality.yml` | Auto-approve, Copilot review, merge readiness checks |
-| **Release** | `release.yml` | SBOM generation, Cosign signing, GitHub Release creation, TER publish |
-| **Security** | `security.yml` | Dependency audit, Trivy scanning, security analysis |
-| **CodeQL** | `codeql.yml` | GitHub code scanning for vulnerabilities |
-| **Dependency Review** | `dependency-review.yml` | Review new dependencies in PRs |
-| **Scorecard** | `scorecard.yml` | OpenSSF Scorecard supply-chain security |
-| **Publish to TER** | `publish-to-ter.yml` | TYPO3 Extension Repository publishing |
-| **Auto-merge Deps** | `auto-merge-deps.yml` | Auto-merge Renovate dependency updates |
+| File | Purpose |
+|------|---------|
+| `ci.yml` | Test matrix PHP 8.2–8.5 × TYPO3 ^13.4/^14.3 incl. functional tests, coverage upload |
+| `checks.yml` | Security audit, gitleaks, zizmor, fuzz, license check |
+| `testing.yml` | Extended testing (shared extended-testing reusable) |
+| `docs.yml` | TYPO3 documentation rendering |
+| `release.yml` | TYPO3 extension release + TER publish |
+| `harness-verify.yml` | Agent-harness consistency check (`Build/Scripts/verify-harness.sh`) |
+| `republish.yml`, `auto-merge-deps.yml`, `labeler.yml`, `community.yml`, `check-template-drift.yml` | Housekeeping |
 
 ## Code Style
 
-### PHP Standards
-
-- **Base:** PSR-12 + PER-CS 2.0
-- **Strict types:** Required in all files (`declare(strict_types=1);`)
-- **PHP version:** 8.2+ baseline (code must be compatible with PHP 8.2 through 8.5)
-- **Config:** `Build/.php-cs-fixer.dist.php`
-
-### Key Rules
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace Netresearch\T3Cowriter\Controller;
-
-use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
-use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
-use Netresearch\T3Cowriter\Service\RateLimiterInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Log\LoggerInterface;
-use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Http\JsonResponse;
-
-final readonly class AjaxController
-{
-    public function __construct(
-        private LlmServiceManagerInterface $llmServiceManager,
-        private LlmConfigurationRepository $configurationRepository,
-        private RateLimiterInterface $rateLimiter,
-        private Context $context,
-        private LoggerInterface $logger,
-    ) {}
-
-    public function chatAction(ServerRequestInterface $request): ResponseInterface
-    {
-        // Implementation...
-        return new JsonResponse($response);
-    }
-}
-```
-
-### JavaScript Standards
-
-- **ES6 modules:** CKEditor 5 plugin format
-- **TYPO3 AJAX:** Use TYPO3.settings.ajaxUrls
-- **Style:** Follow CKEditor 5 conventions
-- **Location:** `Resources/Public/JavaScript/Ckeditor/`
+- PSR-12 + PER-CS 2.0; `declare(strict_types=1);` in every PHP file; PHP 8.2 baseline (must stay compatible through 8.5)
+- PHPStan level 10; refresh baseline only via `composer ci:test:php:phpstan:baseline`
+- Prefer `final readonly` classes, constructor promotion, DI via [Configuration/Services.yaml](Configuration/Services.yaml)
+- JavaScript: ES modules, CKEditor 5 plugin conventions, ESLint ([eslint.config.js](eslint.config.js)), no jQuery
 
 ## Security
 
-- **No API keys in frontend:** All LLM calls via backend nr-llm
-- **AJAX routes:** Protected by TYPO3 backend authentication
-- **Input validation:** Type-cast all request parameters
-- **XSS prevention:** JsonResponse for API output
-- **Static analysis:** PHPStan level 10
+- No API keys in the frontend — all LLM calls go through backend controllers and nr-llm
+- AJAX routes require TYPO3 backend authentication; rate limiting via `RateLimiterService`
+- LLM output is returned raw in JSON and sanitized on the frontend — do not escape it server-side (see [Classes/AGENTS.md](Classes/AGENTS.md))
 
 ## PR/Commit Checklist
 
-Before committing:
+1. `composer ci:test` green; tests updated and green (`composer ci:test:all`, `npm test`)
+2. Conventional Commits: `type(scope): subject` — scopes: `backend`, `frontend`, `config`, `docs`, `build`, `ddev`
+3. Signed commits with DCO sign-off required: `git commit -S --signoff` (see [CONTRIBUTING.md](CONTRIBUTING.md))
+4. Update Documentation/ and CHANGELOG.md for user-facing changes; keep AGENTS.md in sync when commands or CI change
 
-1. **Lint passed:** `make lint`
-2. **Style fixed:** `make cgl-fix`
-3. **Tests pass:** `make test`
-4. **Static analysis:** No new PHPStan errors
-5. **Rector check:** No modernization suggestions
-6. **Docs updated:** Update relevant docs if API changed
-7. **CHANGELOG:** Add entry if user-facing change
-8. **Conventional Commits:** Use format: `type(scope): message`
+## Index of scoped AGENTS.md
 
-### Commit Format
+- `./Classes/AGENTS.md` — PHP backend: controllers, DTOs, services, nr-llm integration
+- `./Resources/AGENTS.md` — JavaScript/CKEditor 5 frontend, icons, backend templates
+- `./Tests/AGENTS.md` — Test suites: unit, functional, integration, E2E, JavaScript
 
-```
-<type>(<scope>): <subject>
+## When Instructions Conflict
 
-[optional body]
-```
-
-**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
-**Scopes:** `backend`, `frontend`, `config`, `docs`, `build`, `ddev`
-
-**Examples:**
-```
-feat(backend): add streaming support for chat responses
-fix(frontend): handle empty AI responses gracefully
-docs(api): update AjaxController endpoint documentation
-```
-
-## Good vs Bad Examples
-
-### Good: TYPO3 AJAX Controller
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace Netresearch\T3Cowriter\Controller;
-
-use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
-use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Http\JsonResponse;
-
-final readonly class AjaxController
-{
-    public function __construct(
-        private LlmServiceManagerInterface $llmServiceManager,
-        private LlmConfigurationRepository $configurationRepository,
-    ) {}
-
-    public function chatAction(ServerRequestInterface $request): ResponseInterface
-    {
-        $body = json_decode($request->getBody()->getContents(), true);
-        $messages = $body['messages'] ?? [];
-
-        $configuration = $this->configurationRepository->findDefault();
-        $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration);
-
-        return new JsonResponse($response);
-    }
-}
-```
-
-### Bad: Direct API calls from frontend
-
-```javascript
-// DON'T: Exposing API keys to browser
-const response = await fetch('https://api.openai.com/v1/chat', {
-    headers: { 'Authorization': `Bearer ${apiKey}` }  // API key in frontend!
-});
-```
-
-### Good: Use TYPO3 AJAX routes
-
-```javascript
-// DO: Use TYPO3 AJAX routes
-const response = await fetch(TYPO3.settings.ajaxUrls.tx_cowriter_chat, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ messages }),
-});
-```
-
-## When Stuck
-
-1. **Architecture:** Check nr-llm repository for LLM integration patterns
-2. **CKEditor 5:** See TYPO3 rte_ckeditor documentation; plugin registered in `Configuration/RTE/Cowriter.yaml`
-3. **AJAX Routes:** Check `Configuration/Backend/AjaxRoutes.php`
-4. **DI Issues:** Verify `Configuration/Services.yaml` registration
-5. **Version compatibility:** Code must work on both TYPO3 v13.4 and v14.3; check CI matrix in `.github/workflows/ci.yml`
-
-### Common Issues
-
-- **LLM not responding:** Check nr-llm extension configuration
-- **AJAX 403 error:** User not logged into backend
-- **PHPStan errors:** Update baseline: `composer ci:test:php:phpstan:baseline`
-- **Code style fails:** Run `make cgl-fix` to auto-fix
-
-## House Rules
-
-### Design Principles
-
-- **Security first:** No API keys in frontend, all calls via backend
-- **SOLID:** Single responsibility, dependency injection
-- **KISS:** Keep it simple
-- **Composition > Inheritance:** Prefer composition
-
-### Dependencies
-
-- **Supported versions:** TYPO3 13.4 LTS + 14.3, PHP 8.2+
-- **Renovate:** Auto-updates enabled
-- **nr-llm:** Primary LLM abstraction layer
-
-### API & Versioning
-
-- **SemVer:** Semantic versioning (MAJOR.MINOR.PATCH)
-- **Breaking changes:** Increment major version
-- **Deprecations:** Add `@deprecated` tag + removal plan
-
-## Related Files
-
-**Directory-specific guides:**
-- **[Classes/AGENTS.md](Classes/AGENTS.md)** - PHP backend components
-- **[Resources/AGENTS.md](Resources/AGENTS.md)** - JavaScript/CKEditor integration
-- **[Tests/AGENTS.md](Tests/AGENTS.md)** - Test suite structure
-
-**Configuration:**
-- **[composer.json](composer.json)** - Dependencies & scripts (PHP ^8.2, TYPO3 ^13.4 || ^14.3)
-- **[Configuration/RTE/Cowriter.yaml](Configuration/RTE/Cowriter.yaml)** - CKEditor plugin registration
-- **[Build/](Build/)** - Development tools configuration
-
-**CI/CD:**
-- **[.github/workflows/](/.github/workflows/)** - GitHub Actions workflows
-
-**Documentation:**
-- **[Documentation/](Documentation/)** - RST documentation
-- **[README.md](README.md)** - Project overview
-
-## Additional Resources
-
-- **Repository:** https://github.com/netresearch/t3x-cowriter
-- **nr-llm:** https://github.com/netresearch/t3x-nr-llm
-- **TYPO3 Docs:** https://docs.typo3.org/
-- **CKEditor 5:** https://ckeditor.com/docs/ckeditor5/
-
-## Commit Signing
-
-Signed commits are required: `git commit -S --signoff`. The `require-signed-commits` ruleset on the default branch rejects unsigned commits at merge time, and the DCO check additionally requires the `Signed-off-by` trailer. Quickest setup is SSH signing — register your SSH key as a *signing key* on your GitHub account, then `git config --global gpg.format ssh && git config --global user.signingkey ~/.ssh/<key>.pub`.
+Nearest AGENTS.md wins. Explicit user prompts override files.

--- a/Build/Scripts/verify-harness.sh
+++ b/Build/Scripts/verify-harness.sh
@@ -1,0 +1,756 @@
+#!/usr/bin/env bash
+# verify-harness.sh — Portable harness consistency checker
+# Checks AGENTS.md and related files for agent harness maturity.
+# Dependencies: coreutils + git (jq optional, graceful fallback)
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+ERRORS=0
+WARNINGS=0
+FORMAT=""
+MAX_LEVEL=3
+SINGLE_CHECK=""
+STATUS_ONLY=false
+PLATFORM="${PLATFORM:-}"
+
+# Collected output lines (for final rendering)
+declare -a OUTPUT_LINES=()
+declare -a GITHUB_LINES=()
+declare -a GITLAB_LINES=()
+
+# Per-level pass/total counters
+declare -A LEVEL_PASS=( [1]=0 [2]=0 [3]=0 )
+declare -A LEVEL_TOTAL=( [1]=0 [2]=0 [3]=0 )
+
+# Track the first failing level-1 suggestion for --status
+NEXT_STEP=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<'USAGE'
+Usage: verify-harness.sh [OPTIONS]
+
+Verify agent harness consistency in the current repository.
+Must be run from the repo root.
+
+Options:
+  --format=text     Plain text output (default for terminals)
+  --format=github   GitHub Actions annotations (auto-detected in CI)
+  --format=gitlab   GitLab CI section annotations (auto-detected in CI)
+  --platform=P      Target platform: github, gitlab or forgejo (auto-detected
+                    from CI environment or git remote URL if not specified)
+  --level=N         Only check up to level N (1, 2, or 3; default: all)
+  --check=NAME      Run single check category: refs, commands, drift, structure
+  --status          Show current maturity level summary only
+  --help            Show this help message
+
+Exit codes:
+  0  All checks pass
+  1  Errors found (Level 1/2 failures)
+  2  Only warnings (Level 3 suggestions)
+USAGE
+    exit 0
+}
+
+# Detect output format: github if running in CI, otherwise text
+detect_format() {
+    if [[ -n "$FORMAT" ]]; then
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        FORMAT="github"
+    elif [[ "${GITLAB_CI:-}" == "true" ]]; then
+        FORMAT="gitlab"
+    else
+        FORMAT="text"
+    fi
+}
+
+# Detect hosting platform from CI env, git remote, or flag
+detect_platform() {
+    if [[ -n "$PLATFORM" ]]; then
+        if [[ "$PLATFORM" != "github" && "$PLATFORM" != "gitlab" && "$PLATFORM" != "forgejo" ]]; then
+            echo "Error: Unsupported PLATFORM '${PLATFORM}'. Expected 'github', 'gitlab' or 'forgejo'." >&2
+            exit 1
+        fi
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        # Forgejo/Gitea Actions also export GITHUB_ACTIONS=true; tell them apart
+        # by the server URL — github.com (or a *.github.* Enterprise host) is real
+        # GitHub, anything else is a self-hosted Forgejo/Gitea instance.
+        if [[ -n "${GITHUB_SERVER_URL:-}" && "${GITHUB_SERVER_URL}" != *"github."* ]]; then
+            PLATFORM="forgejo"
+        else
+            PLATFORM="github"
+        fi
+        return
+    fi
+    if [[ "${GITLAB_CI:-}" == "true" ]]; then
+        PLATFORM="gitlab"
+        return
+    fi
+    local remote_url=""
+    remote_url=$(git remote get-url origin 2>/dev/null || true)
+    if [[ "$remote_url" == *"forgejo"* || "$remote_url" == *"gitea"* ]]; then
+        PLATFORM="forgejo"
+    elif [[ "$remote_url" == *"github"* ]]; then
+        PLATFORM="github"
+    elif [[ "$remote_url" == *"gitlab"* ]]; then
+        PLATFORM="gitlab"
+    elif [[ -f ".gitlab-ci.yml" ]]; then
+        # Infer GitLab from CI config presence (e.g. self-hosted GitLab)
+        PLATFORM="gitlab"
+    elif [[ -d ".forgejo" || -d ".gitea" ]]; then
+        # Infer Forgejo/Gitea from config presence (self-hosted)
+        PLATFORM="forgejo"
+    elif [[ -d ".github" ]]; then
+        PLATFORM="github"
+    else
+        PLATFORM="github"
+    fi
+}
+
+# Record a passing check
+pass() {
+    local level="$1"
+    local msg="$2"
+    (( LEVEL_PASS[$level]++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  PASS|${level}|${msg}")
+}
+
+# Record a failing check (error)
+fail() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( ERRORS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  FAIL|${level}|${msg}")
+    GITHUB_LINES+=("::error file=${file}::${msg} -- required for Level ${level} harness maturity")
+    GITLAB_LINES+=("ERROR: [Level ${level}] ${msg}${file:+ (${file})}")
+    # Capture first actionable suggestion for --status
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# Record a warning
+warn() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( WARNINGS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  WARN|${level}|${msg}")
+    GITHUB_LINES+=("::warning file=${file}::${msg}")
+    GITLAB_LINES+=("WARNING: [Level ${level}] ${msg}${file:+ (${file})}")
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Level 1 checks — Basic
+# ---------------------------------------------------------------------------
+check_agents_md_exists() {
+    if [[ -f "AGENTS.md" ]]; then
+        pass 1 "AGENTS.md exists"
+    else
+        fail 1 "AGENTS.md missing at repo root"
+    fi
+}
+
+check_agents_md_length() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "AGENTS.md length check skipped (file missing)"
+        return
+    fi
+    local lines
+    lines=$(wc -l < "AGENTS.md")
+    if (( lines < 150 )); then
+        pass 1 "AGENTS.md is index-format (${lines} lines)"
+    else
+        fail 1 "AGENTS.md is ${lines} lines (should be under 150)"
+    fi
+}
+
+check_agents_md_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "Commands section check skipped (AGENTS.md missing)"
+        return
+    fi
+    if grep -qi '^## *\(available \)\?commands' "AGENTS.md"; then
+        pass 1 "Commands section found"
+    else
+        fail 1 "AGENTS.md missing ## Commands section"
+    fi
+}
+
+check_docs_exists() {
+    if [[ -d "docs" ]]; then
+        pass 1 "docs/ directory exists"
+    else
+        fail 1 "docs/ directory missing" ""
+    fi
+}
+
+run_level1() {
+    check_agents_md_exists
+    check_agents_md_length
+    check_agents_md_commands
+    check_docs_exists
+}
+
+# ---------------------------------------------------------------------------
+# Level 2 checks — Verified
+# ---------------------------------------------------------------------------
+
+# Check that all local file references in AGENTS.md resolve
+check_refs() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Reference check skipped (AGENTS.md missing)"
+        return
+    fi
+    local has_broken=false
+    # Extract markdown links: [text](path) — skip http(s):// and #anchors
+    while IFS= read -r ref; do
+        # Strip anchor (#...) and query string (?...)
+        local clean
+        clean="${ref%%#*}"
+        clean="${clean%%\?*}"
+        # Skip empty after stripping
+        [[ -z "$clean" ]] && continue
+        # Skip URLs
+        [[ "$clean" =~ ^https?:// ]] && continue
+        # Check if file/dir exists
+        if [[ ! -e "$clean" ]]; then
+            warn 2 "Broken reference in AGENTS.md: ${ref} -> ${clean} not found"
+            has_broken=true
+        fi
+    done < <(grep -oP '\]\(\K[^)]+' "AGENTS.md" 2>/dev/null || true)
+
+    if [[ "$has_broken" == false ]]; then
+        pass 2 "All references resolve"
+    fi
+}
+
+# Check that documented commands have matching targets/scripts
+check_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Command check skipped (AGENTS.md missing)"
+        return
+    fi
+
+    local found_any=false
+
+    # -- Makefile targets --
+    if [[ -f "Makefile" ]]; then
+        found_any=true
+        local has_make_issue=false
+        while IFS= read -r target; do
+            # Check if Makefile defines this target (pattern: "target:" at start of line)
+            if ! grep -qE "^${target}[[:space:]]*:" "Makefile"; then
+                warn 2 "make ${target}: no matching Makefile target (warning)"
+                has_make_issue=true
+            fi
+        done < <(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_make_issue" == false ]]; then
+            local make_count
+            make_count=$(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$make_count" -gt 0 ]]; then
+                pass 2 "All make targets verified (${make_count} targets)"
+            fi
+        fi
+    fi
+
+    # -- composer.json scripts --
+    if [[ -f "composer.json" ]]; then
+        found_any=true
+        local has_composer_issue=false
+        # Built-in composer commands that are NOT user-defined scripts
+        local composer_builtins="install|update|require|remove|dump-autoload|dumpautoload|clear-cache|clearcache|config|create-project|exec|global|init|outdated|prohibits|why|why-not|search|self-update|selfupdate|show|status|validate|archive|browse|check-platform-reqs|diagnose|fund|licenses|run-script|suggests|upgrade"
+        while IFS= read -r script; do
+            # Skip built-in composer commands
+            if echo "$script" | grep -qE "^(${composer_builtins})$"; then
+                continue
+            fi
+            # Look for the script name in composer.json's scripts section
+            # Using grep since jq is optional
+            if ! grep -qE "\"${script}\"" "composer.json"; then
+                warn 2 "composer ${script}: no matching composer.json script (warning)"
+                has_composer_issue=true
+            fi
+        done < <(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_composer_issue" == false ]]; then
+            local composer_count
+            composer_count=$(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$composer_count" -gt 0 ]]; then
+                pass 2 "All composer scripts verified (${composer_count} scripts)"
+            fi
+        fi
+    fi
+
+    # -- package.json scripts --
+    if [[ -f "package.json" ]]; then
+        found_any=true
+        local has_npm_issue=false
+        while IFS= read -r script; do
+            if ! grep -qE "\"${script}\"" "package.json"; then
+                warn 2 "npm run ${script}: no matching package.json script (warning)"
+                has_npm_issue=true
+            fi
+        done < <(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_npm_issue" == false ]]; then
+            local npm_count
+            npm_count=$(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$npm_count" -gt 0 ]]; then
+                pass 2 "All npm scripts verified (${npm_count} scripts)"
+            fi
+        fi
+    fi
+
+    if [[ "$found_any" == false ]]; then
+        pass 2 "No build system files found to check commands against"
+    fi
+}
+
+check_architecture_doc() {
+    if [[ -f "docs/ARCHITECTURE.md" ]]; then
+        pass 2 "docs/ARCHITECTURE.md exists"
+    else
+        fail 2 "docs/ARCHITECTURE.md missing" ""
+    fi
+}
+
+check_ci_workflow() {
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -f ".gitlab-ci.yml" ]]; then
+            # Search root file and all include:local files for harness job
+            local found_harness=false
+            if grep -qE "harness-verify|verify-harness" ".gitlab-ci.yml"; then
+                found_harness=true
+            else
+                # Check files referenced via include:local (supports globs).
+                # Portable parser using sed/awk — handles common GitLab CI forms:
+                #   include: { local: 'path' }
+                #   include:
+                #     - local: 'path'
+                #   include:
+                #     - local:
+                #         - path1
+                #         - path2
+                # Skips PCRE (-P) and lookaround for BSD/macOS grep portability.
+                while IFS= read -r inc_pattern; do
+                    [[ -z "$inc_pattern" ]] && continue
+                    # shellcheck disable=SC2086
+                    for inc_file in $inc_pattern; do
+                        if [[ -f "$inc_file" ]] && grep -qE "harness-verify|verify-harness" "$inc_file"; then
+                            found_harness=true
+                            break 2
+                        fi
+                    done
+                done < <(awk '
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*\[/ {
+                        # inline list form: local: [a.yml, b.yml]
+                        s=$0; sub(/.*local:[[:space:]]*\[/,"",s); sub(/\].*/,"",s);
+                        n=split(s, a, /[[:space:]]*,[[:space:]]*/);
+                        for (i=1;i<=n;i++) print a[i]; next
+                    }
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*[^[:space:]\[]/ {
+                        # scalar form: local: path or - local: path
+                        s=$0; sub(/.*local:[[:space:]]*/,"",s); print s; next
+                    }
+                ' ".gitlab-ci.yml" 2>/dev/null | tr -d "'\"" || true)
+            fi
+            if [[ "$found_harness" == true ]]; then
+                pass 2 "CI harness job found in GitLab CI config"
+            else
+                warn 2 "CI config exists (.gitlab-ci.yml) but no harness-verify job found"
+            fi
+        else
+            fail 2 "CI harness workflow missing -- create .gitlab-ci.yml with a harness-verify job" ""
+        fi
+    elif [[ "$PLATFORM" == "forgejo" ]]; then
+        if [[ -f ".forgejo/workflows/harness-verify.yml" || -f ".gitea/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .forgejo/workflows/harness-verify.yml" ""
+        fi
+    else
+        if [[ -f ".github/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .github/workflows/harness-verify.yml" ""
+        fi
+    fi
+}
+
+run_level2() {
+    check_refs
+    check_commands
+    check_architecture_doc
+    check_ci_workflow
+}
+
+# ---------------------------------------------------------------------------
+# Level 3 checks — Enforced
+# ---------------------------------------------------------------------------
+
+check_hooks_autosetup() {
+    local found=false
+    local via=""
+
+    # Check .envrc for hooksPath
+    if [[ -f ".envrc" ]] && grep -q "hooksPath" ".envrc"; then
+        found=true
+        via=".envrc"
+    fi
+
+    # Check for Husky
+    if [[ -d ".husky" ]]; then
+        found=true
+        via=".husky"
+    fi
+
+    # Check composer.json for post-install-cmd with hooks
+    if [[ -f "composer.json" ]] && grep -q "post-install-cmd" "composer.json"; then
+        if grep -q "hook" "composer.json"; then
+            found=true
+            via="composer.json post-install-cmd"
+        fi
+    fi
+
+    if [[ "$found" == true ]]; then
+        pass 3 "Git hooks auto-setup via ${via}"
+    else
+        warn 3 "No git hooks auto-setup detected (.envrc hooksPath, .husky/, or composer.json post-install-cmd)"
+    fi
+}
+
+check_pr_template() {
+    if [[ "$PLATFORM" == "forgejo" ]]; then
+        # Forgejo/Gitea honour PR templates under .forgejo/, .gitea/ or .github/
+        local f
+        for f in .forgejo/pull_request_template.md .gitea/pull_request_template.md \
+                 .forgejo/PULL_REQUEST_TEMPLATE.md .gitea/PULL_REQUEST_TEMPLATE.md \
+                 .github/pull_request_template.md; do
+            if [[ -f "$f" ]]; then
+                pass 3 "PR template exists ($f)"
+                return
+            fi
+        done
+        warn 3 "PR template missing (create .forgejo/pull_request_template.md)"
+        return
+    fi
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -d ".gitlab/merge_request_templates" ]]; then
+            local tmpl_count
+            tmpl_count=$(find .gitlab/merge_request_templates -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+            if (( tmpl_count > 0 )); then
+                pass 3 "MR template exists (.gitlab/merge_request_templates/, ${tmpl_count} template(s))"
+                return
+            fi
+        fi
+        warn 3 "MR template missing (create .gitlab/merge_request_templates/Default.md)"
+    else
+        if [[ -f ".github/pull_request_template.md" ]]; then
+            pass 3 "PR template exists (repo-level)"
+            return
+        fi
+        if [[ -d ".github/PULL_REQUEST_TEMPLATE" ]]; then
+            pass 3 "PR template exists (directory form)"
+            return
+        fi
+        local org=""
+        org=$(git remote get-url origin 2>/dev/null | sed -n 's|.*github\.com[:/]\([^/]*\)/.*|\1|p')
+        if [[ -n "$org" ]]; then
+            local api_result=""
+            api_result=$(gh api "repos/${org}/.github/contents/pull_request_template.md" --jq '.name' 2>/dev/null || true)
+            if [[ "$api_result" == "pull_request_template.md" ]]; then
+                pass 3 "PR template exists (org-level via ${org}/.github)"
+                return
+            fi
+        fi
+        warn 3 "PR template missing (.github/pull_request_template.md or org-level)"
+    fi
+}
+
+check_drift() {
+    # Skip if git is not available
+    if ! command -v git &>/dev/null; then
+        pass 3 "Drift check skipped (git not available)"
+        return
+    fi
+
+    # Skip if not in a git repo
+    if ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (not a git repository)"
+        return
+    fi
+
+    # Skip if no parent commit (initial commit)
+    if ! git rev-parse HEAD~1 &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (no parent commit)"
+        return
+    fi
+
+    # Check if build/CI files changed in last commit
+    local build_files_changed=false
+    local agents_changed=false
+
+    while IFS= read -r changed_file; do
+        case "$changed_file" in
+            Makefile|composer.json|package.json|.github/workflows/*|.gitlab-ci.yml|.forgejo/workflows/*|.gitea/workflows/*)
+                build_files_changed=true
+                ;;
+            AGENTS.md)
+                agents_changed=true
+                ;;
+        esac
+    done < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+
+    if [[ "$build_files_changed" == true && "$agents_changed" == false ]]; then
+        warn 3 "Potential drift: build/CI files changed in last commit but AGENTS.md was not updated"
+    else
+        pass 3 "No drift detected"
+    fi
+}
+
+run_level3() {
+    check_hooks_autosetup
+    check_pr_template
+    check_drift
+}
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+render_text() {
+    echo "Agent Harness Verification"
+    echo "=========================="
+    echo ""
+
+    local current_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for line in "${OUTPUT_LINES[@]}"; do
+        local kind level msg
+        kind="${line%%|*}"
+        local rest="${line#*|}"
+        level="${rest%%|*}"
+        msg="${rest#*|}"
+        kind="${kind#"${kind%%[![:space:]]*}"}" # trim leading whitespace
+
+        # Print level header when level changes
+        if (( level != current_level )); then
+            if (( current_level != 0 )); then
+                echo ""
+            fi
+            echo "Level ${level} -- ${level_names[$level]}"
+            current_level=$level
+        fi
+
+        case "$kind" in
+            PASS) echo "  ✓ ${msg}" ;;
+            FAIL) echo "  ✗ ${msg}" ;;
+            WARN) echo "  ! ${msg}" ;;
+        esac
+    done
+
+    echo ""
+
+    # Summary line
+    local maturity_level=0
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status="COMPLETE"
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        maturity_level=1
+    elif (( maturity_level < 3 )); then
+        # Check if next level is partially done
+        local next_lvl=$(( maturity_level + 1 ))
+        if (( ${LEVEL_TOTAL[$next_lvl]} > 0 && ${LEVEL_PASS[$next_lvl]} < ${LEVEL_TOTAL[$next_lvl]} )); then
+            status="PARTIAL"
+        fi
+    fi
+
+    echo "Summary: Level ${maturity_level} ${status} | ${ERRORS} error(s), ${WARNINGS} warning(s)"
+}
+
+render_github() {
+    if (( ${#GITHUB_LINES[@]} > 0 )); then
+        for line in "${GITHUB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+}
+
+render_gitlab() {
+    local ts
+    ts=$(date +%s)
+    echo -e "\e[0Ksection_start:${ts}:harness_verify[collapsed=false]\r\e[0KAgent Harness Verification"
+    if (( ${#GITLAB_LINES[@]} > 0 )); then
+        for line in "${GITLAB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+    echo ""
+    echo "Summary: ${ERRORS} error(s), ${WARNINGS} warning(s)"
+    echo -e "\e[0Ksection_end:${ts}:harness_verify\r\e[0K"
+}
+
+render_status() {
+    # Determine highest fully-passing level
+    local maturity_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        # Display as Level 1 when no level is fully complete
+        local display_level=1
+        echo "Harness Maturity: Level ${display_level} (${level_names[$display_level]}) -- ${status}"
+    else
+        echo "Harness Maturity: Level ${maturity_level} (${level_names[$maturity_level]}) -- COMPLETE"
+    fi
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 )); then
+            echo "  Level ${lvl}: ${LEVEL_PASS[$lvl]}/${LEVEL_TOTAL[$lvl]} checks pass"
+        fi
+    done
+
+    if [[ -n "$NEXT_STEP" ]]; then
+        echo "Next step: ${NEXT_STEP}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --format=*)
+                FORMAT="${1#--format=}"
+                ;;
+            --platform=*)
+                PLATFORM="${1#--platform=}"
+                if [[ ! "$PLATFORM" =~ ^(github|gitlab|forgejo)$ ]]; then
+                    echo "Error: --platform must be 'github', 'gitlab' or 'forgejo'" >&2
+                    exit 1
+                fi
+                ;;
+            --level=*)
+                MAX_LEVEL="${1#--level=}"
+                if [[ ! "$MAX_LEVEL" =~ ^[123]$ ]]; then
+                    echo "Error: --level must be 1, 2, or 3" >&2
+                    exit 1
+                fi
+                ;;
+            --check=*)
+                SINGLE_CHECK="${1#--check=}"
+                ;;
+            --status)
+                STATUS_ONLY=true
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                echo "Run with --help for usage info" >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    detect_format
+    detect_platform
+
+    # Run single check category if requested
+    if [[ -n "$SINGLE_CHECK" ]]; then
+        case "$SINGLE_CHECK" in
+            refs)       check_refs ;;
+            commands)   check_commands ;;
+            drift)      check_drift ;;
+            structure)
+                check_agents_md_exists
+                check_docs_exists
+                check_architecture_doc
+                check_ci_workflow
+                check_pr_template
+                ;;
+            *)
+                echo "Unknown check: ${SINGLE_CHECK}" >&2
+                echo "Valid checks: refs, commands, drift, structure" >&2
+                exit 1
+                ;;
+        esac
+    else
+        # Run all checks up to MAX_LEVEL
+        if (( MAX_LEVEL >= 1 )); then
+            run_level1
+        fi
+        if (( MAX_LEVEL >= 2 )); then
+            run_level2
+        fi
+        if (( MAX_LEVEL >= 3 )); then
+            run_level3
+        fi
+    fi
+
+    # Render output
+    if [[ "$STATUS_ONLY" == true ]]; then
+        render_status
+    elif [[ "$FORMAT" == "github" ]]; then
+        render_github
+    elif [[ "$FORMAT" == "gitlab" ]]; then
+        render_gitlab
+    else
+        render_text
+    fi
+
+    # Exit code
+    if (( ERRORS > 0 )); then
+        exit 1
+    elif (( WARNINGS > 0 )); then
+        exit 2
+    else
+        exit 0
+    fi
+}
+
+main "$@"

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -1,29 +1,49 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
 # AGENTS.md - Classes (PHP Backend)
 
 **Scope:** PHP backend components for t3_cowriter TYPO3 extension
 **Parent:** [../AGENTS.md](../AGENTS.md)
 
-## Files to Create/Maintain
+## Overview
+
+PHP source of the extension, PSR-4 autoloaded under `Netresearch\T3Cowriter\`. Controllers answer the backend AJAX routes defined in `../Configuration/Backend/AjaxRoutes.php`, DTOs parse and validate request/response payloads, and services wrap diagnostics, context assembly, rate limiting, and LLM error classification. All LLM calls go through nr-llm's `LlmServiceManagerInterface`.
+
+## Setup
+
+```bash
+composer install     # Installs to .Build/vendor (bin-dir .Build/bin)
+```
+
+Dependency injection is configured in `../Configuration/Services.yaml`; new services are picked up automatically via autowiring, interfaces need an explicit alias there.
+
+## Key Files
 
 | File | Purpose |
 |------|---------|
 | Controller/AjaxController.php | AJAX handler for CKEditor integration |
 | Controller/Backend/StatusController.php | Setup status diagnostic page (admin only) |
+| Controller/RateLimitedControllerTrait.php | Shared rate-limit check for controllers |
 | Controller/TranslationController.php | Content translation endpoint |
 | Controller/VisionController.php | Image analysis (alt text) |
 | Controller/TemplateController.php | Prompt template listing |
 | Controller/ToolController.php | LLM function calling |
 | Domain/DTO/CompleteRequest.php | Request DTO with validation |
 | Domain/DTO/CompleteResponse.php | Response DTO with HTML escaping |
+| Domain/DTO/ContextRequest.php | Context preview request DTO |
 | Domain/DTO/ExecuteTaskRequest.php | Task execution request DTO |
+| Domain/DTO/PageSearchResult.php | Page search result DTO (tx_cowriter_page_search) |
+| Domain/DTO/ToolRequest.php | Tool/function calling request DTO |
 | Domain/DTO/TranslationRequest.php | Translation request DTO |
 | Domain/DTO/UsageData.php | Token usage statistics |
+| Domain/DTO/VisionRequest.php | Vision/alt-text request DTO |
 | EventListener/InjectAjaxUrlsListener.php | AJAX URL injection for frontend |
 | Service/DiagnosticService.php | 8-step LLM config chain checker |
 | Service/Dto/Severity.php | Check severity enum (Ok/Warning/Error) |
 | Service/Dto/DiagnosticCheck.php | Individual check result DTO |
 | Service/Dto/DiagnosticResult.php | Aggregate diagnostic result |
-| Service/ContextAssemblyService.php | Context assembly for task execution |
+| Service/ContextAssemblyService.php | Context assembly for task execution (`ContextAssemblyServiceInterface`) |
+| Service/LlmErrorClassifier.php | Classifies provider failures (`LlmErrorKind` enum) |
 | Service/RateLimiterInterface.php | Rate limiter abstraction for DI |
 | Service/RateLimiterService.php | Sliding window rate limiter implementation |
 | Service/RateLimitResult.php | Rate limit check result DTO |
@@ -97,14 +117,10 @@ if ($this->isConfigurationError($exception)) {
 ## Build & Tests
 
 ```bash
-# Unit tests (via make -> composer)
-make test-unit
-
-# With coverage
-make test-coverage
-
-# PHPStan level 10
-make phpstan
+composer ci:test:php:unit    # Unit tests
+composer ci:test:php:phpstan # PHPStan level 10
+composer ci:test             # Full quality suite (lint + phpstan + rector + cgl)
+make test-coverage           # Coverage report (unit + integration, needs DDEV)
 ```
 
 ## Code Style
@@ -201,6 +217,13 @@ public function completeAction($request)
     return new JsonResponse(['content' => $response->content]); // unhandled ProviderException, no rate limit
 }
 ```
+
+## When Stuck
+
+1. **AJAX routing:** Routes live in `../Configuration/Backend/AjaxRoutes.php`; a 403 usually means no backend login
+2. **DI failures:** Check `../Configuration/Services.yaml` (interface aliases are explicit)
+3. **LLM behavior:** Read the nr-llm extension (https://github.com/netresearch/t3x-nr-llm) — configuration chain is provider → model → configuration
+4. **Setup errors:** `DiagnosticService::runFirst()` mirrors the backend status module (`cowriter_status`) and names the first broken step
 
 ## Related
 

--- a/Classes/CLAUDE.md
+++ b/Classes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Resources/AGENTS.md
+++ b/Resources/AGENTS.md
@@ -1,3 +1,5 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
 # Resources/AGENTS.md
 
 **Scope:** JavaScript/CKEditor 5 integration and frontend assets
@@ -11,6 +13,7 @@ Frontend components for t3_cowriter CKEditor integration. JavaScript communicate
 
 - **AIService.js** - API client for backend communication (chat, complete, stream)
 - **cowriter.js** - CKEditor 5 plugin integration
+- **CowriterDialog.js** - Task dialog UI (incl. status link on errors)
 - **UrlLoader.js** - CSP-compliant AJAX URL injection from data attributes
 
 ### File Structure
@@ -24,9 +27,30 @@ Resources/
 │   │   └── ModuleIcon.legacy.svg  # Backend module icon, TYPO3 v13 (teal tile variant)
 │   └── JavaScript/
 │       └── Ckeditor/
-│           ├── AIService.js   # AJAX API client
-│           ├── cowriter.js    # CKEditor plugin
-│           └── UrlLoader.js   # CSP-compliant URL loader
+│           ├── AIService.js       # AJAX API client
+│           ├── cowriter.js        # CKEditor plugin
+│           ├── CowriterDialog.js  # Task dialog UI
+│           └── UrlLoader.js       # CSP-compliant URL loader
+├── Private/
+│   ├── Language/locallang_mod_status.xlf   # Status module labels
+│   └── Templates/Backend/Status/Index.html # Status module Fluid template
+```
+
+## Setup
+
+```bash
+npm install          # Node dev-dependencies (ESLint, Vitest, Playwright)
+```
+
+No build step: the JavaScript ships as-is as native ES modules — edit the files under `Public/JavaScript/Ckeditor/` directly.
+
+## Build & Tests
+
+```bash
+npm run lint         # ESLint (flat config in ../eslint.config.js)
+npm run lint:fix     # ESLint auto-fix
+npm test             # Vitest unit tests (../Tests/JavaScript/)
+npm run test:e2e     # Playwright E2E specs (../Tests/E2E/)
 ```
 
 ## Architecture

--- a/Resources/CLAUDE.md
+++ b/Resources/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,7 +1,22 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
 # AGENTS.md - Tests
 
-**Scope:** Unit and functional tests for t3_cowriter
+**Scope:** Test suites for t3_cowriter
 **Parent:** [../AGENTS.md](../AGENTS.md)
+
+## Overview
+
+Multi-layer test suite: PHP unit, functional, integration, and E2E tests (PHPUnit via `../Build/Scripts/runTests.sh`, configs in `../Build/phpunit/`), JavaScript unit tests (Vitest, `JavaScript/`), and browser E2E specs (Playwright, `E2E/*.spec.ts`). CI runs the PHP suites across the PHP 8.2–8.5 × TYPO3 ^13.4/^14.3 matrix.
+
+## Setup
+
+```bash
+composer install     # PHP test stack (.Build/vendor, .Build/bin)
+npm install          # Vitest + Playwright
+```
+
+PHP suites run in Docker containers via `../Build/Scripts/runTests.sh` — Docker or Podman must be running.
 
 ## Coverage Targets
 
@@ -66,7 +81,7 @@
 | 16 | rateLimitedIncludesRetryAfter | Rate limit response |
 | 17 | jsonSerializeFormatsCorrectly | JSON output |
 
-## Test Execution Commands
+## Commands
 
 **CI is authoritative** - always verify fixes pass in GitHub Actions CI before merging.
 Run tests locally via composer (same commands as CI).
@@ -86,6 +101,10 @@ composer ci:test:all
 
 # Full CI suite (lint + static analysis + tests)
 composer ci:test && composer ci:test:all
+
+# JavaScript
+npm test             # Vitest (JavaScript/)
+npm run test:e2e     # Playwright (E2E/*.spec.ts)
 ```
 
 ## Test Structure
@@ -93,45 +112,22 @@ composer ci:test && composer ci:test:all
 ```
 Tests/
 ├── Unit/
-│   ├── Controller/
-│   │   ├── AjaxControllerTest.php
-│   │   ├── TranslationControllerTest.php
-│   │   ├── VisionControllerTest.php
-│   │   ├── TemplateControllerTest.php
-│   │   └── ToolControllerTest.php
-│   ├── Domain/DTO/
-│   │   ├── CompleteRequestTest.php
-│   │   ├── CompleteResponseTest.php
-│   │   ├── ExecuteTaskRequestTest.php
-│   │   ├── TranslationRequestTest.php
-│   │   ├── ToolRequestTest.php
-│   │   └── UsageDataTest.php
-│   ├── EventListener/
-│   │   └── InjectAjaxUrlsListenerTest.php
-│   └── Service/
-│       ├── ContextAssemblyServiceTest.php
-│       ├── DiagnosticServiceTest.php
-│       ├── RateLimiterServiceTest.php
-│       └── RateLimitResultTest.php
+│   ├── Controller/     # Ajax, Template, Tool, Translation, Vision controller tests
+│   ├── Domain/DTO/     # CompleteRequest (+ fuzz), CompleteResponse, ContextRequest,
+│   │                   # ExecuteTaskRequest, ToolRequest, TranslationRequest, UsageData, VisionRequest
+│   ├── EventListener/  # InjectAjaxUrlsListenerTest.php
+│   └── Service/        # ContextAssemblyService, DiagnosticService, LlmErrorClassifier,
+│                       # RateLimiterService, RateLimitResult tests
+├── Functional/         # Placeholder (.gitkeep) — suite wired in CI, no tests yet
 ├── Integration/
 │   ├── AbstractIntegrationTestCase.php
-│   └── Controller/
-│       ├── AjaxControllerIntegrationTest.php
-│       ├── Backend/
-│       │   └── StatusControllerIntegrationTest.php
-│       ├── TranslationControllerIntegrationTest.php
-│       └── VisionControllerIntegrationTest.php
+│   └── Controller/     # Ajax, Template, Translation, Vision + Backend/Status integration tests
 ├── E2E/
-│   ├── AbstractE2ETestCase.php
-│   ├── CowriterWorkflowTest.php
-│   └── NewFeatureWorkflowTest.php
-├── JavaScript/                           # Vitest tests for frontend
-│   ├── AIService.test.js
-│   ├── cowriter.test.js
-│   ├── CowriterDialog.test.js
-│   └── UrlLoader.test.js
-└── Support/
-    └── TestQueryResult.php
+│   ├── AbstractE2ETestCase.php, CowriterWorkflowTest.php, NewFeatureWorkflowTest.php  # PHP E2E
+│   ├── *.spec.ts       # Playwright specs (toolbar, dialog, tasks, translate, vision, context zoom)
+│   └── fixtures/       # Playwright auth fixture
+├── JavaScript/         # Vitest: AIService, cowriter, CowriterDialog, UrlLoader (+ __mocks__/)
+└── Support/            # TestQueryResult.php, TaskStubTrait.php
 ```
 
 ## TYPO3 Final Class Workarounds
@@ -166,7 +162,7 @@ grep -rn "new TranslationController(" Tests/
 ```
 This includes Unit/, Integration/, AND E2E/ tests.
 
-## PHPUnit Attributes
+## Conventions (PHPUnit Attributes)
 
 Use PHPUnit 12 attribute syntax:
 
@@ -199,7 +195,12 @@ final class AjaxControllerTest extends TestCase
 }
 ```
 
-## Mocking nr-llm
+## Security
+
+- Verify output handling in tests: HTML escaping/sanitization test cases are mandatory for anything that renders LLM output
+- Never put real API keys or credentials in fixtures — mock `LlmServiceManagerInterface` (below); Playwright auth uses the local DDEV instance only
+
+## Examples: Mocking nr-llm
 
 ```php
 private LlmServiceManagerInterface&MockObject $llmManager;
@@ -235,6 +236,13 @@ public function testWithMockedResponse(): void
 4. **DataProviders:** For multiple input scenarios
 5. **Edge cases:** Empty, null, invalid inputs
 6. **Security tests:** HTML escaping verified
+
+## When Stuck
+
+- **Suite won't start:** `runTests.sh` needs a running Docker/Podman daemon
+- **Mock errors on final classes:** see "TYPO3 Final Class Workarounds" above
+- **Playwright failures:** run headed (`npm run test:e2e:headed`) against the DDEV instance (`make up`)
+- **Coverage attribution missing:** add `#[CoversClass]` for every exercised class
 
 ## Related
 

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# Architecture
+
+Agent-facing component map. For user documentation see `Documentation/` (RST, rendered to docs.typo3.org).
+
+## System Overview
+
+t3_cowriter integrates AI assistance into the TYPO3 CKEditor 5 RTE. The frontend plugin (registered as RTE preset `cowriter` in `ext_localconf.php` → `Configuration/RTE/Cowriter.yaml`) calls backend AJAX routes; controllers delegate every LLM call to the `netresearch/nr-llm` extension via `LlmServiceManagerInterface`, so no API keys ever reach the browser. A backend module (`cowriter_status`) runs an 8-step diagnostic chain to troubleshoot the LLM configuration.
+
+## Components
+
+| Component | Path | Responsibility |
+|-----------|------|----------------|
+| CKEditor plugin | `Resources/Public/JavaScript/Ckeditor/cowriter.js` | Toolbar items, editor integration |
+| Task dialog | `Resources/Public/JavaScript/Ckeditor/CowriterDialog.js` | Task dialog UI, status link on errors |
+| API client | `Resources/Public/JavaScript/Ckeditor/AIService.js` | Fetch wrapper for all AJAX routes, `AIServiceError` |
+| URL loader | `Resources/Public/JavaScript/Ckeditor/UrlLoader.js` | CSP-compliant AJAX URL injection |
+| AJAX routes | `Configuration/Backend/AjaxRoutes.php` | 12 route definitions (see table below) |
+| Main controller | `Classes/Controller/AjaxController.php` | Chat, complete, stream (SSE), configurations, tasks, task execution, context, page search |
+| Vision controller | `Classes/Controller/VisionController.php` | Image analysis / alt-text generation |
+| Translation controller | `Classes/Controller/TranslationController.php` | Content translation |
+| Template controller | `Classes/Controller/TemplateController.php` | Prompt template listing |
+| Tool controller | `Classes/Controller/ToolController.php` | LLM tool/function calling |
+| Status module | `Classes/Controller/Backend/StatusController.php`, `Configuration/Backend/Modules.php` | Setup diagnostics page (`cowriter_status`) |
+| Diagnostics | `Classes/Service/DiagnosticService.php` | 8-step config chain check (provider → model → configuration) |
+| Context assembly | `Classes/Service/ContextAssemblyService.php` | Builds page/content context for task execution |
+| Rate limiting | `Classes/Service/RateLimiterService.php`, `Classes/Controller/RateLimitedControllerTrait.php` | Sliding-window limiter backed by the `cowriter_ratelimit` cache (`ext_localconf.php`) |
+| Error classification | `Classes/Service/LlmErrorClassifier.php` | Maps provider failures to `LlmErrorKind` for user-facing messages |
+| DTOs | `Classes/Domain/DTO/` | Request parsing/validation and response shaping per endpoint |
+| DI configuration | `Configuration/Services.yaml` | Autowiring, interface aliases, public controller services |
+
+## AJAX Routes
+
+| Route | Target |
+|-------|--------|
+| `tx_cowriter_chat` | `AjaxController::chatAction` |
+| `tx_cowriter_complete` | `AjaxController::completeAction` |
+| `tx_cowriter_stream` | `AjaxController::streamAction` (SSE) |
+| `tx_cowriter_configurations` | `AjaxController::getConfigurationsAction` |
+| `tx_cowriter_tasks` | `AjaxController::getTasksAction` |
+| `tx_cowriter_task_execute` | `AjaxController::executeTaskAction` |
+| `tx_cowriter_context` | `AjaxController::getContextAction` |
+| `tx_cowriter_page_search` | `AjaxController::searchPagesAction` |
+| `tx_cowriter_vision` | `VisionController::analyzeAction` |
+| `tx_cowriter_translate` | `TranslationController::translateAction` |
+| `tx_cowriter_templates` | `TemplateController::listAction` |
+| `tx_cowriter_tools` | `ToolController::executeAction` |
+
+## Data Flow
+
+```
+CKEditor Toolbar
+  ├─ cowriter          → CowriterDialog → AIService.js → AjaxController
+  ├─ cowriterVision    → AIService.js ─────────────────→ VisionController
+  ├─ cowriterTranslate → AIService.js ─────────────────→ TranslationController
+  └─ cowriterTemplates → AIService.js ─────────────────→ TemplateController
+                                                               ↓
+                                                    LlmServiceManagerInterface
+                                                          (nr-llm)
+                                                               ↓
+                                                     Provider → AI API
+```
+
+Controllers rate-limit first (`RateLimitedControllerTrait`), parse the request into a DTO, resolve the LLM configuration, and return `JsonResponse`. LLM output is returned raw in JSON; the frontend sanitizes it before it enters the editor (see `Classes/AGENTS.md` — do not escape server-side).
+
+## Key Decisions
+
+- **No frontend LLM access**: all provider credentials and calls live in nr-llm behind backend authentication (`Classes/AGENTS.md`, root `AGENTS.md` Security section).
+- **Rate-limit cache via CacheManager, not DI**: extension caches are not available as DI services during container compilation; see the comment in `ext_localconf.php`.
+- **Raw LLM output contract**: server returns unescaped content, frontend owns sanitization — documented in `Classes/AGENTS.md`.
+- **CI via shared reusables**: all workflows delegate to `netresearch/typo3-ci-workflows` / `netresearch/.github`; the per-repo matrix lives in `.github/workflows/ci.yml`.

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,8 @@
+# Execution Plans
+
+Working directory for agent execution plans (multi-step changes, refactors, upgrades).
+
+- `active/` — plans currently being executed
+- `completed/` — finished plans kept for reference
+
+Keep plans short: goal, ordered steps, verification commands. Delete or move to `completed/` when done. This directory is part of the agent-harness structure verified by `Build/Scripts/verify-harness.sh`.


### PR DESCRIPTION
Closes #155.

## Explain the details

Syncs all AGENTS.md files with the verified repo state and adopts the agent-harness Level 2/3 verification, mirroring netresearch/t3x-rte_ckeditor_image#888 / netresearch/t3x-rte_ckeditor_image#890.

**AGENTS.md sync** — every claim was verified against its source (composer.json scripts, Makefile targets, `.github/workflows/*.yml`, `Configuration/Backend/AjaxRoutes.php`, `Configuration/Services.yaml`, the actual file trees): the root workflow table now lists the ten real workflows (thin callers of `netresearch/typo3-ci-workflows` / `netresearch/.github` reusables) instead of six nonexistent ones; phantom make targets (`make lint`, `make cgl-fix`, `make test`, `make test-unit`, `make phpstan`) replaced with the real `composer ci:*` commands; the AJAX route inventory now covers all 12 routes incl. `tx_cowriter_page_search`; the Classes/Resources/Tests inventories match the tree again (RateLimitedControllerTrait, 4 missing DTOs, LlmErrorClassifier/LlmErrorKind, CowriterDialog.js, Playwright specs, fuzz test, TaskStubTrait). Curated content (raw-LLM-output contract, nr-llm budget metadata, final-class workarounds, coverage targets) is preserved. The root is restructured as a thin index (411 → 100 lines) with managed header, precedence statement, scope index, and a pointer to the version in `ext_emconf.php` instead of a pinned number.

**Convention** — `CLAUDE.md` symlinks added next to the three scoped AGENTS.md files; all files carry the managed header and the required sections (validate-structure.sh now passes with 0 errors / 0 warnings).

**Agent-harness Level 2/3** — adds `docs/ARCHITECTURE.md` (component map, route table, and data flow, all paths and targets verified), `docs/exec-plans/README.md`, `Build/Scripts/verify-harness.sh`, and `.github/workflows/harness-verify.yml` as a thin caller of the shared `script-check` reusable (exit 2 = warnings-only passes). The `docs/` gitignore entry ("Planning docs") had to go — the harness docs structure must be tracked, otherwise the CI check cannot see it.

Known remaining warning: `verify-harness.sh` reports "No git hooks auto-setup detected". The repo has captainhook + hook-installer available via `netresearch/typo3-ci-workflows` but no captainhook.json / husky / hooksPath setup; adding hook infrastructure is a functional change beyond this docs sync and is left out deliberately.

## Test plan

- `validate-structure.sh`: 8 errors / 4 warnings → **0 errors / 0 warnings**
- `verify-content.sh`: **all checks pass**
- `score-agents.sh`: average 58/100 (root 43) → **91/100** (root 90, Classes 94, Tests 94, Resources 86)
- `verify-harness.sh`: Level 1 PARTIAL, 5 errors / 7 warnings → **Level 2 complete / Level 3 partial, 0 errors / 1 warning** (hooks auto-setup, see above)
- Root AGENTS.md: 411 → 100 lines (cap 150); markdown fences balanced in all touched files; every referenced repo path checked for existence
