### PR TITLE
feat(backend): name this extension on every nr-llm call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Unreleased
 
+## CHANGE
+
+- Every LLM call names this extension (`t3_cowriter`) and the editor action
+  that triggered it as its caller source, so the nr-llm Analytics module
+  attributes usage and cost to cowriter instead of listing it as
+  "Unattributed". Operations: `chat`, `complete`, `streamComplete`, the task
+  identifier (or `customInstruction` when no task is selected) for task
+  execution, `altText`, `translate` and `toolCall`.
+- Alt text, translation and tool calling carry the identity on the options
+  object. nr-llm 0.31.1 discards it before dispatch — `VisionService` and
+  `TranslationService` rebuild their options without the field, and
+  `ToolLoopService` forwards only budget metadata — so those three endpoints
+  stay unattributed until nr-llm forwards it
+  ([nr-llm#845](https://github.com/netresearch/t3x-nr-llm/issues/845)). Chat,
+  completion, streaming and task execution use the metadata channel and are
+  attributed today.
+
 # 3.6.4 (2026-08-20)
 
 ## CHANGE

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -38,6 +38,7 @@ Dependency injection is configured in `../Configuration/Services.yaml`; new serv
 | Domain/DTO/UsageData.php | Token usage statistics |
 | Domain/DTO/VisionRequest.php | Vision/alt-text request DTO |
 | EventListener/InjectAjaxUrlsListener.php | AJAX URL injection for frontend |
+| Service/CallerSource.php | Extension key + pipeline metadata naming this extension to nr-llm telemetry |
 | Service/DiagnosticService.php | 8-step LLM config chain checker |
 | Service/Dto/Severity.php | Check severity enum (Ok/Warning/Error) |
 | Service/Dto/DiagnosticCheck.php | Individual check result DTO |
@@ -77,11 +78,19 @@ content: $response->content,
 ```php
 // Use LlmServiceManagerInterface for all LLM operations. Resolve a configuration
 // and pass the backend user id as budget metadata so per-user nr-llm
-// BudgetMiddleware enforcement applies to the call.
+// BudgetMiddleware enforcement applies to the call, plus the caller identity so
+// the Analytics module attributes the call to this extension.
 $configuration = $this->configurationRepository->findDefault();
-$metadata      = [BudgetMiddleware::METADATA_BE_USER_UID => $beUserUid];
+$metadata      = [BudgetMiddleware::METADATA_BE_USER_UID => $beUserUid]
+    + CallerSource::metadata('chat');
 $response      = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $metadata);
 ```
+
+Calls that take an options object instead of a metadata array (vision,
+translation, tool loop) tag the identity with
+`AbstractOptions::withCallerSource(CallerSource::EXTENSION, '<operation>')`. The
+operation is the editor action, named per call site — never one constant for the
+whole extension.
 
 ### Response Handling
 

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -23,6 +23,7 @@ use Netresearch\T3Cowriter\Domain\DTO\CompleteResponse;
 use Netresearch\T3Cowriter\Domain\DTO\ContextRequest;
 use Netresearch\T3Cowriter\Domain\DTO\ExecuteTaskRequest;
 use Netresearch\T3Cowriter\Domain\DTO\PageSearchResult;
+use Netresearch\T3Cowriter\Service\CallerSource;
 use Netresearch\T3Cowriter\Service\ContextAssemblyServiceInterface;
 use Netresearch\T3Cowriter\Service\DiagnosticService;
 use Netresearch\T3Cowriter\Service\Dto\DiagnosticCheck;
@@ -165,7 +166,7 @@ final readonly class AjaxController
         }
 
         try {
-            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $this->budgetMetadata());
+            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $this->callMetadata('chat'));
 
             return $this->jsonResponseWithRateLimitHeaders([
                 'success'      => true,
@@ -259,7 +260,7 @@ final readonly class AjaxController
                 ['role' => 'user', 'content' => $dto->prompt],
             ];
 
-            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $this->budgetMetadata());
+            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $this->callMetadata('complete'));
 
             return $this->jsonResponseWithRateLimitHeaders(
                 CompleteResponse::success($response)->jsonSerialize(),
@@ -338,7 +339,7 @@ final readonly class AjaxController
         // This implementation collects chunks and returns them in SSE format for compatibility
         try {
             $chunks    = [];
-            $generator = $this->llmServiceManager->streamChatWithConfiguration($messages, $configuration, [], $this->budgetMetadata());
+            $generator = $this->llmServiceManager->streamChatWithConfiguration($messages, $configuration, [], $this->callMetadata('streamComplete'));
 
             foreach ($generator as $chunk) {
                 $chunks[] = 'data: ' . json_encode(['content' => $chunk], JSON_THROW_ON_ERROR) . "\n\n";
@@ -635,7 +636,11 @@ final readonly class AjaxController
         }
 
         try {
-            $response = $this->llmServiceManager->chatWithConfiguration($messages, $configuration, $this->budgetMetadata());
+            $response = $this->llmServiceManager->chatWithConfiguration(
+                $messages,
+                $configuration,
+                $this->callMetadata($this->taskOperation($task)),
+            );
 
             // Post-process: convert markdown to HTML if the model ignored the formatting instruction
             $rawContent       = $response->content;
@@ -900,15 +905,39 @@ final readonly class AjaxController
     }
 
     /**
-     * nr-llm budget-attribution metadata for the current backend user, so
-     * per-user BudgetMiddleware enforcement applies to cowriter traffic.
-     * A uid of 0 (no session) is passed through and skipped by the middleware.
+     * nr-llm pipeline metadata for one call: budget attribution for the current
+     * backend user, so per-user BudgetMiddleware enforcement applies to cowriter
+     * traffic (a uid of 0 — no session — is passed through and skipped by the
+     * middleware), plus the caller identity so Analytics attributes the call to
+     * this extension instead of listing it as unattributed.
      *
-     * @return array<string, int>
+     * @param string $operation the editor action that triggered the call
+     *
+     * @return array<string, int|string>
      */
-    private function budgetMetadata(): array
+    private function callMetadata(string $operation): array
     {
-        return [BudgetMiddleware::METADATA_BE_USER_UID => $this->currentBackendUserId()];
+        return [BudgetMiddleware::METADATA_BE_USER_UID => $this->currentBackendUserId()]
+            + CallerSource::metadata($operation);
+    }
+
+    /**
+     * The caller-source operation for a task execution.
+     *
+     * Task identifiers are the editor-facing action names ("rewrite",
+     * "summarize", …), so they are the meaningful unit here. A task without an
+     * identifier falls back to the action name; taskUid 0 is the custom-
+     * instruction mode, which has no task at all.
+     */
+    private function taskOperation(?Task $task): string
+    {
+        if (!$task instanceof Task) {
+            return 'customInstruction';
+        }
+
+        $identifier = $task->getIdentifier();
+
+        return $identifier !== '' ? $identifier : 'executeTask';
     }
 
     /**

--- a/Classes/Controller/ToolController.php
+++ b/Classes/Controller/ToolController.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Netresearch\T3Cowriter\Domain\DTO\ToolRequest;
+use Netresearch\T3Cowriter\Service\CallerSource;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -120,12 +121,17 @@ final readonly class ToolController
                 ? ToolExecutionContext::fromBackendUser($backendUser)
                 : ToolExecutionContext::none();
 
+            // withCallerSource() names this extension on the telemetry row so
+            // Analytics attributes tool calls to it (nr-llm ADR-177). nr-llm
+            // 0.31.1 does not deliver it yet: ToolLoopService forwards only
+            // budget metadata onto the chat calls it makes, so these calls stay
+            // unattributed until nr-llm#845 lands.
             $result = $this->toolLoopService->runLoop(
                 $messages,
                 $configuration,
                 $context,
                 $allowedToolNames,
-                ToolOptions::auto(),
+                ToolOptions::auto()->withCallerSource(CallerSource::EXTENSION, 'toolCall'),
             );
 
             return $this->jsonResponseWithRateLimitHeaders([

--- a/Classes/Controller/TranslationController.php
+++ b/Classes/Controller/TranslationController.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Service\Option\TranslationOptions;
 use Netresearch\NrLlm\Specialized\Translation\LlmTranslator;
 use Netresearch\NrLlm\Specialized\Translation\TranslatorInterface;
 use Netresearch\T3Cowriter\Domain\DTO\TranslationRequest;
+use Netresearch\T3Cowriter\Service\CallerSource;
 use Netresearch\T3Cowriter\Service\DiagnosticService;
 use Netresearch\T3Cowriter\Service\Dto\DiagnosticCheck;
 use Netresearch\T3Cowriter\Service\LlmErrorClassifier;
@@ -91,10 +92,17 @@ final readonly class TranslationController
         }
 
         try {
+            // withCallerSource() names this extension on the telemetry row so
+            // Analytics attributes translations to it (nr-llm ADR-177).
+            // nr-llm 0.31.1 does not deliver it yet: TranslationService drops
+            // the field on every path it offers, so these calls stay
+            // unattributed until nr-llm#845 lands.
             $options = (new TranslationOptions(
                 formality: $translationRequest->formality,
                 domain: $translationRequest->domain,
-            ))->withBeUserUid((int) $userId);
+            ))
+                ->withBeUserUid((int) $userId)
+                ->withCallerSource(CallerSource::EXTENSION, 'translate');
 
             // When an editor pins a stored configuration, route through the
             // per-configuration path (nr-llm 0.22, #428) so the configuration's

--- a/Classes/Controller/VisionController.php
+++ b/Classes/Controller/VisionController.php
@@ -12,6 +12,7 @@ namespace Netresearch\T3Cowriter\Controller;
 use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\T3Cowriter\Domain\DTO\VisionRequest;
+use Netresearch\T3Cowriter\Service\CallerSource;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -76,7 +77,15 @@ final readonly class VisionController
             // altText() preset (detail 'low', maxTokens 100, temperature 0.5)
             // matches this alt-text endpoint; analyzeImageFull() still returns the
             // model/confidence/usage metadata the response surfaces.
-            $options  = VisionOptions::altText()->withBeUserUid((int) $userId);
+            // withCallerSource() names this extension on the telemetry row so
+            // Analytics attributes alt-text generation to it (nr-llm ADR-177).
+            // nr-llm 0.31.1 does not deliver it yet: analyzeImageFull() rebuilds
+            // the options object without the field, so these calls stay
+            // unattributed until nr-llm#845 lands.
+            $options = VisionOptions::altText()
+                ->withBeUserUid((int) $userId)
+                ->withCallerSource(CallerSource::EXTENSION, 'altText');
+
             $response = $this->visionService->analyzeImageFull(
                 $visionRequest->imageUrl,
                 $visionRequest->prompt,

--- a/Classes/Service/CallerSource.php
+++ b/Classes/Service/CallerSource.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\T3Cowriter\Service;
+
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
+
+/**
+ * Caller identity this extension reports to nr-llm telemetry (nr-llm ADR-177).
+ *
+ * Without it every cowriter request is recorded as an anonymous call and the
+ * nr-llm Analytics module lists its usage and cost under "Unattributed".
+ *
+ * Two channels carry the identity. Calls that pass an options object tag it
+ * with `AbstractOptions::withCallerSource()`; calls that go straight to
+ * `LlmServiceManagerInterface::*WithConfiguration()` pass {@see self::metadata()}
+ * instead, because those methods take a metadata array and no options object.
+ */
+final class CallerSource
+{
+    /**
+     * The TER extension key — not the composer package name.
+     */
+    public const EXTENSION = 't3_cowriter';
+
+    /**
+     * Pipeline metadata naming this extension and $operation as the caller.
+     *
+     * @param string $operation the editor action that triggered the call
+     *
+     * @return array<string, string>
+     */
+    public static function metadata(string $operation): array
+    {
+        return [
+            TelemetryMiddleware::METADATA_SOURCE_EXTENSION => self::EXTENSION,
+            TelemetryMiddleware::METADATA_SOURCE_OPERATION => $operation,
+        ];
+    }
+}

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -256,53 +256,47 @@ final class AjaxControllerTest extends TestCase
         self::assertSame('streamComplete', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
     }
 
+    /**
+     * A stored task reports its own identifier, and an identifier-less one
+     * falls back to the action name. Two cases of one rule, so one test —
+     * they differed only in the identifier the task mock returns.
+     */
     #[Test]
-    public function executeTaskActionReportsTheTaskIdentifierAsCallerSourceOperation(): void
-    {
+    #[DataProvider('taskOperations')]
+    public function executeTaskActionReportsTheTaskIdentifierAsCallerSourceOperation(
+        int $taskUid,
+        string $taskIdentifier,
+        string $expectedOperation,
+    ): void {
         $config = $this->createConfigurationMock();
         $this->configRepositoryMock->method('findDefault')->willReturn($config);
 
         $task = $this->createMock(Task::class);
         $task->method('isActive')->willReturn(true);
-        $task->method('getIdentifier')->willReturn('summarize');
+        $task->method('getIdentifier')->willReturn($taskIdentifier);
         $task->method('getConfiguration')->willReturn(null);
-        $this->taskRepositoryMock->method('findByUid')->with(7)->willReturn($task);
+        $this->taskRepositoryMock->method('findByUid')->with($taskUid)->willReturn($task);
 
         $captured = $this->captureChatMetadata();
 
         $this->subject->executeTaskAction($this->createRequestWithJsonBody([
-            'taskUid'     => 7,
+            'taskUid'     => $taskUid,
             'instruction' => 'Shorten this',
             'context'     => 'Some text',
             'contextType' => 'selection',
         ]));
 
         self::assertSame('t3_cowriter', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
-        self::assertSame('summarize', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
+        self::assertSame($expectedOperation, $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
     }
 
-    #[Test]
-    public function executeTaskActionFallsBackToTheActionNameForAnIdentifierlessTask(): void
+    /**
+     * @return iterable<string, array{int, string, string}>
+     */
+    public static function taskOperations(): iterable
     {
-        $config = $this->createConfigurationMock();
-        $this->configRepositoryMock->method('findDefault')->willReturn($config);
-
-        $task = $this->createMock(Task::class);
-        $task->method('isActive')->willReturn(true);
-        $task->method('getIdentifier')->willReturn('');
-        $task->method('getConfiguration')->willReturn(null);
-        $this->taskRepositoryMock->method('findByUid')->with(9)->willReturn($task);
-
-        $captured = $this->captureChatMetadata();
-
-        $this->subject->executeTaskAction($this->createRequestWithJsonBody([
-            'taskUid'     => 9,
-            'instruction' => 'Do the thing',
-            'context'     => 'Some text',
-            'contextType' => 'selection',
-        ]));
-
-        self::assertSame('executeTask', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
+        yield 'a task with an identifier reports it' => [7, 'summarize', 'summarize'];
+        yield 'an identifier-less task falls back to the action name' => [9, '', 'executeTask'];
     }
 
     /**

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
 
 use Doctrine\DBAL\Result;
+use Generator;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Task;
@@ -19,6 +20,7 @@ use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\T3Cowriter\Controller\AjaxController;
 use Netresearch\T3Cowriter\Service\ContextAssemblyServiceInterface;
@@ -173,7 +175,161 @@ final class AjaxControllerTest extends TestCase
         $this->subject->chatAction($request);
 
         // contextMock->getPropertyFromAspect returns 1 for the backend user id.
-        self::assertSame([BudgetMiddleware::METADATA_BE_USER_UID => 1], $captured);
+        self::assertSame([
+            BudgetMiddleware::METADATA_BE_USER_UID         => 1,
+            TelemetryMiddleware::METADATA_SOURCE_EXTENSION => 't3_cowriter',
+            TelemetryMiddleware::METADATA_SOURCE_OPERATION => 'chat',
+        ], $captured);
+    }
+
+    #[Test]
+    public function chatActionNamesThisExtensionAndOperationAsCallerSource(): void
+    {
+        $config = $this->createConfigurationMock();
+        $this->configRepositoryMock->method('findDefault')->willReturn($config);
+
+        $captured = $this->captureChatMetadata();
+
+        $this->subject->chatAction(
+            $this->createRequestWithJsonBody(['messages' => [['role' => 'user', 'content' => 'Hello']]]),
+        );
+
+        self::assertSame('t3_cowriter', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
+        self::assertSame('chat', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
+    }
+
+    #[Test]
+    public function completeActionNamesThisExtensionAndOperationAsCallerSource(): void
+    {
+        $config = $this->createConfigurationMock();
+        $this->configRepositoryMock->method('findDefault')->willReturn($config);
+
+        $captured = $this->captureChatMetadata();
+
+        $this->subject->completeAction($this->createRequestWithJsonBody(['prompt' => 'Write something']));
+
+        self::assertSame('t3_cowriter', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
+        self::assertSame('complete', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
+    }
+
+    #[Test]
+    public function streamActionNamesThisExtensionAndOperationAsCallerSource(): void
+    {
+        $config = $this->createConfigurationMock();
+        $this->configRepositoryMock->method('findDefault')->willReturn($config);
+
+        $captured           = new stdClass();
+        $captured->metadata = null;
+        $this->llmServiceManagerMock
+            ->method('streamChatWithConfiguration')
+            ->willReturnCallback(
+                function (array $m, $c, array $overrides = [], array $metadata = []) use ($captured): Generator {
+                    $captured->metadata = $metadata;
+
+                    yield 'chunk';
+                },
+            );
+
+        $this->subject->streamAction($this->createRequestWithJsonBody(['prompt' => 'Write something']));
+
+        self::assertSame('t3_cowriter', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
+        self::assertSame('streamComplete', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
+    }
+
+    #[Test]
+    public function executeTaskActionReportsTheTaskIdentifierAsCallerSourceOperation(): void
+    {
+        $config = $this->createConfigurationMock();
+        $this->configRepositoryMock->method('findDefault')->willReturn($config);
+
+        $task = $this->createMock(Task::class);
+        $task->method('isActive')->willReturn(true);
+        $task->method('getIdentifier')->willReturn('summarize');
+        $task->method('getConfiguration')->willReturn(null);
+        $this->taskRepositoryMock->method('findByUid')->with(7)->willReturn($task);
+
+        $captured = $this->captureChatMetadata();
+
+        $this->subject->executeTaskAction($this->createRequestWithJsonBody([
+            'taskUid'     => 7,
+            'instruction' => 'Shorten this',
+            'context'     => 'Some text',
+            'contextType' => 'selection',
+        ]));
+
+        self::assertSame('t3_cowriter', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
+        self::assertSame('summarize', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
+    }
+
+    #[Test]
+    public function executeTaskActionReportsCustomInstructionWhenNoTaskIsSelected(): void
+    {
+        $config = $this->createConfigurationMock();
+        $this->configRepositoryMock->method('findDefault')->willReturn($config);
+
+        $captured = $this->captureChatMetadata();
+
+        $this->subject->executeTaskAction($this->createRequestWithJsonBody([
+            'taskUid'     => 0,
+            'instruction' => 'Make it friendlier',
+            'context'     => 'Some text',
+            'contextType' => 'selection',
+        ]));
+
+        self::assertSame('t3_cowriter', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
+        self::assertSame(
+            'customInstruction',
+            $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null,
+        );
+    }
+
+    #[Test]
+    public function executeTaskActionFallsBackToTheActionNameForAnIdentifierlessTask(): void
+    {
+        $config = $this->createConfigurationMock();
+        $this->configRepositoryMock->method('findDefault')->willReturn($config);
+
+        $task = $this->createMock(Task::class);
+        $task->method('isActive')->willReturn(true);
+        $task->method('getIdentifier')->willReturn('');
+        $task->method('getConfiguration')->willReturn(null);
+        $this->taskRepositoryMock->method('findByUid')->with(9)->willReturn($task);
+
+        $captured = $this->captureChatMetadata();
+
+        $this->subject->executeTaskAction($this->createRequestWithJsonBody([
+            'taskUid'     => 9,
+            'instruction' => 'Do the thing',
+            'context'     => 'Some text',
+            'contextType' => 'selection',
+        ]));
+
+        self::assertSame('executeTask', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
+    }
+
+    /**
+     * Capture the metadata array `chatWithConfiguration()` is called with.
+     *
+     * The holder is an object, not an array: the caller reads it after the
+     * action ran, and an array would be returned by value — a copy taken
+     * before the mock was ever invoked.
+     */
+    private function captureChatMetadata(): stdClass
+    {
+        $holder           = new stdClass();
+        $holder->metadata = null;
+
+        $this->llmServiceManagerMock
+            ->method('chatWithConfiguration')
+            ->willReturnCallback(
+                function (array $m, $c, array $metadata = []) use ($holder): CompletionResponse {
+                    $holder->metadata = $metadata;
+
+                    return $this->createCompletionResponse('ok');
+                },
+            );
+
+        return $holder;
     }
 
     #[Test]

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -182,34 +182,54 @@ final class AjaxControllerTest extends TestCase
         ], $captured);
     }
 
+    /**
+     * The endpoints that reach nr-llm through `chatWithConfiguration()` differ
+     * only in the request they take and the operation they report, so they are
+     * one test over a table rather than one method each — which also keeps the
+     * next endpoint from being a copy-paste away.
+     *
+     * @param array<string, mixed> $body
+     */
     #[Test]
-    public function chatActionNamesThisExtensionAndOperationAsCallerSource(): void
-    {
+    #[DataProvider('callerSourceOperations')]
+    public function anActionNamesThisExtensionAndItsOperationAsCallerSource(
+        string $action,
+        array $body,
+        string $expectedOperation,
+    ): void {
         $config = $this->createConfigurationMock();
         $this->configRepositoryMock->method('findDefault')->willReturn($config);
 
         $captured = $this->captureChatMetadata();
 
-        $this->subject->chatAction(
-            $this->createRequestWithJsonBody(['messages' => [['role' => 'user', 'content' => 'Hello']]]),
-        );
+        $this->subject->{$action}($this->createRequestWithJsonBody($body));
 
         self::assertSame('t3_cowriter', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
-        self::assertSame('chat', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
+        self::assertSame($expectedOperation, $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
     }
 
-    #[Test]
-    public function completeActionNamesThisExtensionAndOperationAsCallerSource(): void
+    /**
+     * @return iterable<string, array{string, array<string, mixed>, string}>
+     */
+    public static function callerSourceOperations(): iterable
     {
-        $config = $this->createConfigurationMock();
-        $this->configRepositoryMock->method('findDefault')->willReturn($config);
+        yield 'chat' => [
+            'chatAction',
+            ['messages' => [['role' => 'user', 'content' => 'Hello']]],
+            'chat',
+        ];
 
-        $captured = $this->captureChatMetadata();
+        yield 'completion' => [
+            'completeAction',
+            ['prompt' => 'Write something'],
+            'complete',
+        ];
 
-        $this->subject->completeAction($this->createRequestWithJsonBody(['prompt' => 'Write something']));
-
-        self::assertSame('t3_cowriter', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
-        self::assertSame('complete', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
+        yield 'a task-less instruction' => [
+            'executeTaskAction',
+            ['taskUid' => 0, 'instruction' => 'Make it friendlier', 'context' => 'Some text', 'contextType' => 'selection'],
+            'customInstruction',
+        ];
     }
 
     #[Test]
@@ -259,28 +279,6 @@ final class AjaxControllerTest extends TestCase
 
         self::assertSame('t3_cowriter', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
         self::assertSame('summarize', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
-    }
-
-    #[Test]
-    public function executeTaskActionReportsCustomInstructionWhenNoTaskIsSelected(): void
-    {
-        $config = $this->createConfigurationMock();
-        $this->configRepositoryMock->method('findDefault')->willReturn($config);
-
-        $captured = $this->captureChatMetadata();
-
-        $this->subject->executeTaskAction($this->createRequestWithJsonBody([
-            'taskUid'     => 0,
-            'instruction' => 'Make it friendlier',
-            'context'     => 'Some text',
-            'contextType' => 'selection',
-        ]));
-
-        self::assertSame('t3_cowriter', $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
-        self::assertSame(
-            'customInstruction',
-            $captured->metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null,
-        );
     }
 
     #[Test]

--- a/Tests/Unit/Controller/ToolControllerTest.php
+++ b/Tests/Unit/Controller/ToolControllerTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Netresearch\T3Cowriter\Controller\ToolController;
@@ -127,6 +128,32 @@ final class ToolControllerTest extends TestCase
         ]));
 
         self::assertSame(['query_content'], $captured);
+    }
+
+    #[Test]
+    public function executeActionNamesThisExtensionAndOperationAsCallerSource(): void
+    {
+        $this->allowRateLimit();
+
+        $captured = null;
+        $this->toolLoopServiceStub->method('runLoop')
+            ->willReturnCallback(function (
+                array $messages,
+                LlmConfiguration $config,
+                ToolExecutionContext $context,
+                ?array $allowed,
+                ?ToolOptions $options = null,
+            ) use (&$captured): ToolLoopResult {
+                $captured = $options;
+
+                return $this->loopResult('ok');
+            });
+
+        $this->subject->executeAction($this->createJsonRequest(['prompt' => 'Query']));
+
+        self::assertInstanceOf(ToolOptions::class, $captured);
+        self::assertSame('t3_cowriter', $captured->getCallerSourceExtension());
+        self::assertSame('toolCall', $captured->getCallerSourceOperation());
     }
 
     #[Test]

--- a/Tests/Unit/Controller/TranslationControllerTest.php
+++ b/Tests/Unit/Controller/TranslationControllerTest.php
@@ -54,6 +54,7 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
+use stdClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\Context;
@@ -125,6 +126,88 @@ final class TranslationControllerTest extends TestCase
         self::assertSame(80, $data['usage']['totalTokens']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
+    }
+
+    #[Test]
+    public function translateActionNamesThisExtensionAndOperationAsCallerSource(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $captured          = new stdClass();
+        $captured->options = null;
+
+        $this->translationServiceStub->method('translate')
+            ->willReturnCallback(
+                static function (
+                    string $text,
+                    string $targetLanguage,
+                    ?string $sourceLanguage = null,
+                    ?TranslationOptions $options = null,
+                ) use ($captured): TranslationResult {
+                    $captured->options = $options;
+
+                    return new TranslationResult(
+                        translation: 'Hallo Welt',
+                        sourceLanguage: 'en',
+                        targetLanguage: 'de',
+                        confidence: 0.9,
+                        usage: new UsageStatistics(1, 1, 2),
+                    );
+                },
+            );
+
+        $this->subject->translateAction(
+            $this->createJsonRequest(['text' => 'Hello world', 'targetLanguage' => 'de']),
+        );
+
+        self::assertInstanceOf(TranslationOptions::class, $captured->options);
+        self::assertSame('t3_cowriter', $captured->options->getCallerSourceExtension());
+        self::assertSame('translate', $captured->options->getCallerSourceOperation());
+    }
+
+    #[Test]
+    public function translateActionNamesTheCallerSourceOnThePinnedConfigurationPath(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $this->configurationRepositoryStub->method('findOneByIdentifier')
+            ->willReturn($this->createStub(LlmConfiguration::class));
+
+        $captured          = new stdClass();
+        $captured->options = null;
+
+        $this->translationServiceStub->method('translateForConfiguration')
+            ->willReturnCallback(
+                static function (
+                    string $text,
+                    string $targetLanguage,
+                    LlmConfiguration $configuration,
+                    ?string $sourceLanguage = null,
+                    ?TranslationOptions $options = null,
+                ) use ($captured): TranslationResult {
+                    $captured->options = $options;
+
+                    return new TranslationResult(
+                        translation: 'Hallo Welt',
+                        sourceLanguage: 'en',
+                        targetLanguage: 'de',
+                        confidence: 0.9,
+                        usage: new UsageStatistics(1, 1, 2),
+                    );
+                },
+            );
+
+        $this->subject->translateAction($this->createJsonRequest([
+            'text'           => 'Hello world',
+            'targetLanguage' => 'de',
+            'configuration'  => 'pinned',
+        ]));
+
+        self::assertInstanceOf(TranslationOptions::class, $captured->options);
+        self::assertSame('t3_cowriter', $captured->options->getCallerSourceExtension());
+        self::assertSame('translate', $captured->options->getCallerSourceOperation());
     }
 
     #[Test]

--- a/Tests/Unit/Controller/VisionControllerTest.php
+++ b/Tests/Unit/Controller/VisionControllerTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\T3Cowriter\Tests\Unit\Controller;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Service\Feature\VisionServiceInterface;
+use Netresearch\NrLlm\Service\Option\VisionOptions;
 use Netresearch\T3Cowriter\Controller\VisionController;
 use Netresearch\T3Cowriter\Service\RateLimiterInterface;
 use Netresearch\T3Cowriter\Service\RateLimitResult;
@@ -23,6 +24,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
+use stdClass;
 use TYPO3\CMS\Core\Context\Context;
 
 #[CoversClass(VisionController::class)]
@@ -80,6 +82,36 @@ final class VisionControllerTest extends TestCase
         self::assertSame(150, $data['usage']['totalTokens']);
         self::assertSame('20', $response->getHeaderLine('X-RateLimit-Limit'));
         self::assertSame('19', $response->getHeaderLine('X-RateLimit-Remaining'));
+    }
+
+    #[Test]
+    public function analyzeActionNamesThisExtensionAndOperationAsCallerSource(): void
+    {
+        $this->rateLimiterStub->method('checkLimit')
+            ->willReturn(new RateLimitResult(true, 20, 19, time() + 60));
+
+        $captured          = new stdClass();
+        $captured->options = null;
+
+        $this->visionServiceStub->method('analyzeImageFull')
+            ->willReturnCallback(
+                static function (string $url, string $prompt, ?VisionOptions $options = null) use ($captured): VisionResponse {
+                    $captured->options = $options;
+
+                    return new VisionResponse(
+                        description: 'A cat',
+                        model: 'gpt-4o',
+                        usage: new UsageStatistics(1, 1, 2),
+                        confidence: 0.9,
+                    );
+                },
+            );
+
+        $this->subject->analyzeAction($this->createJsonRequest(['imageUrl' => 'https://example.com/cat.jpg']));
+
+        self::assertInstanceOf(VisionOptions::class, $captured->options);
+        self::assertSame('t3_cowriter', $captured->options->getCallerSourceExtension());
+        self::assertSame('altText', $captured->options->getCallerSourceOperation());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

nr-llm 0.31 breaks Analytics usage and cost down by calling extension (ADR-177/178). Cowriter did not name itself on its calls, so its spend was grouped under "Unattributed". Every call site now carries the extension key `t3_cowriter` plus an operation naming the editor action that triggered it.

| Call site | Channel | Operation |
|---|---|---|
| `AjaxController::chatAction` | metadata | `chat` |
| `AjaxController::completeAction` (via `executeCompletion`) | metadata | `complete` |
| `AjaxController::streamAction` | metadata | `streamComplete` |
| `AjaxController::executeTaskAction` | metadata | task identifier, e.g. `rewrite` / `summarize`; `customInstruction` when taskUid is 0; `executeTask` for a task without an identifier |
| `VisionController::analyzeAction` | options | `altText` |
| `TranslationController::translateAction` (all three paths) | options | `translate` |
| `ToolController::executeAction` | options | `toolCall` |

"metadata" is the `$metadata` array on `LlmServiceManagerInterface::*WithConfiguration()`, whose keys `TelemetryMiddleware` reads directly. "options" is `AbstractOptions::withCallerSource()`.

`Classes/Service/CallerSource.php` holds the extension key and builds the metadata array, so the key is written once.

## Upstream gap: the options path does not arrive in nr-llm 0.31.1

The three options-path endpoints are annotated but **not yet attributed**. nr-llm discards the caller identity before dispatch on every route they can use, so those calls still write an empty origin. Filed as [netresearch/t3x-nr-llm#845](https://github.com/netresearch/t3x-nr-llm/issues/845), with the reproduction below.

- `VisionService::analyzeImageFull()` rebuilds `VisionOptions` field by field before calling the manager. `callerSourceExtension` / `callerSourceOperation` are protected properties set by a wither, not constructor parameters, so the rebuild cannot carry them.
- `TranslationService::translate()` rebuilds `ChatOptions` the same way; `translateForConfiguration()` and `translateWithTranslator()` build their metadata from `budgetMetadata($options)`, which emits only the two `BudgetMiddleware` keys.
- `ToolLoopService` passes `budgetMetadata($options)` into both `chatWithConfiguration()` calls it makes — same two keys.

Verified against v0.31.1 with a mocked `LlmServiceManagerInterface` capturing the options it receives: both `VisionService::analyzeImageFull()` and `TranslationService::translate()` hand on an options object whose `getCallerSourceExtension()` and `getCallerSourceOperation()` are `null`.

The annotation is kept at the call sites regardless: it is the correct expression of the caller's identity, it costs nothing, and these three endpoints start reporting the moment nr-llm forwards the field. Each of the three carries a comment naming the gap so the code does not read as working attribution. Chat, completion, streaming and task execution use the metadata channel and are attributed today.

This is why #161 is referenced rather than closed — three of its seven call sites cannot be delivered from this repository.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issues

Relates to #161. Blocked upstream for the options path: netresearch/t3x-nr-llm#845.

## Checklist

- [x] I have run `make lint` and it passes
- [x] I have run `make test` and all tests pass
- [x] I have updated the documentation if needed
- [x] I have added tests that prove my fix/feature works
- [x] My code follows the project's code style (PSR-12)
- [x] I have updated CHANGELOG.md if this is a user-facing change

## Test Plan

Eleven assertions capture the argument the controller hands to nr-llm and assert both halves of the identity — the metadata array for the four `AjaxController` sites, the options object for vision, translation (default and pinned-configuration paths) and tool calling. Each was seen to fail: with `Classes/` reverted and the tests kept, all eleven fail (`Failed asserting that null is identical to 't3_cowriter'`); they pass on the fixed tree.

Gates run locally, all green:

```
composer ci:test:php:lint         [OK] 70 files
composer ci:test  (phpstan)       [OK] No errors
composer ci:test  (rector -n)     [OK] Rector is done!
composer ci:test  (cgl -n)        Found 0 of 68 files that can be fixed
composer ci:test:php:unit         Tests: 614, Assertions: 1652
Build/phpunit/IntegrationTests.xml Tests: 30, Assertions: 140
Build/phpunit/E2ETests.xml         Tests: 86, Assertions: 397
Build/Scripts/verify-harness.sh    Level 2 PARTIAL | 0 error(s), 1 warning(s)  (warning pre-existing: no git-hook auto-setup)
```

To see attribution end to end, run a chat or task from the RTE against a configured provider and check the Analytics module — the row appears under `t3_cowriter` with the operation. An alt-text or translate run still lands under "Unattributed" until nr-llm#845 lands.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
