### PR TITLE
ci: adopt the shared test runner

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,370 +1,55 @@
 #!/usr/bin/env bash
 
 #
-# TYPO3 Extension Test Runner - t3_cowriter
-# Based on TYPO3 Best Practices: https://github.com/TYPO3BestPractices/tea
+# Bootstrap for the shared TYPO3 extension test runner.
 #
-# This script provides a unified interface for running various test suites
-# and quality tools for the t3_cowriter extension.
+# Copy this file to Build/Scripts/runTests.sh in an extension. It is NOT the
+# runner: the runner is versioned once in netresearch/typo3-ci-workflows and
+# composer links it to .Build/bin/runTests.sh. This stub exists only because
+# the runner provisions the very environment it lives in, so it cannot be
+# behind a completed `composer install` — the first run on a fresh clone has
+# to create it.
 #
-# Usage: ./Build/Scripts/runTests.sh [options] <command>
+# Per-extension settings belong in Build/Scripts/runTests.conf, never here.
+# Anything this stub grows beyond handing over is drift; fix the shared runner
+# instead.
 #
 
-set -e
+set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+cd "$(dirname "$0")/../.."
 
-# Extension root directory
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-
-# Composer binary
-VENDOR_BIN="${ROOT_DIR}/.Build/bin"
-
-# Default values
-PHP_VERSION="${PHP_VERSION:-8.5}"
-DBMS="${DBMS:-sqlite}"
-EXTRA_TEST_OPTIONS=""
-COVERAGE=""
-
-#
-# Print usage information
-#
-usage() {
-    cat << EOF
-TYPO3 Extension Test Runner - t3_cowriter
-
-Usage: $(basename "$0") [OPTIONS] <COMMAND>
-
-Commands:
-    unit              Run unit tests
-    functional        Run functional tests
-    integration       Run integration tests
-    e2e               Run end-to-end tests
-    mutation          Run mutation tests with Infection
-    phpstan           Run PHPStan static analysis
-    cgl               Run PHP-CS-Fixer in dry-run mode
-    cgl:fix           Run PHP-CS-Fixer and apply fixes
-    rector            Run Rector in dry-run mode
-    rector:fix        Run Rector and apply changes
-    ci                Run full CI suite (cgl, phpstan, unit)
-    all               Run all tests and quality checks
-
-Options:
-    -h, --help        Show this help message
-    -v, --verbose     Verbose output
-    -c, --coverage    Generate code coverage report
-    -p, --php         PHP version (default: ${PHP_VERSION})
-    -d, --dbms        Database system for functional tests (default: ${DBMS})
-                      Options: sqlite, mysql, mariadb, postgres
-    -x                Extra options to pass to PHPUnit
-
-Examples:
-    $(basename "$0") unit
-    $(basename "$0") -c unit                  # With coverage
-    $(basename "$0") -x "--filter=testName" unit
-    $(basename "$0") ci
-
-EOF
+# composer.json says where composer puts binaries. Hardcoding .Build/bin was
+# wrong for nine extensions in this fleet: seven use lowercase .build/bin and
+# two use vendor/bin, and there this stub would not have found the runner at
+# all. The runner detects the same thing for itself; the stub has to do it
+# before the runner exists.
+bin_dir() {
+    local dir=""
+    if type jq >/dev/null 2>&1; then
+        dir="$(jq -r '.config["bin-dir"] // ((.config["vendor-dir"] // "vendor") + "/bin") // empty' composer.json 2>/dev/null)"
+    else
+        dir="$(sed -n 's/.*"bin-dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' composer.json | head -n1)"
+        [[ -n "${dir}" ]] || dir="$(sed -n 's/.*"vendor-dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1\/bin/p' composer.json | head -n1)"
+    fi
+    printf '%s' "${dir:-vendor/bin}"
 }
 
-#
-# Print colored message
-#
-info() {
-    echo -e "${BLUE}[INFO]${NC} $1"
-}
+RUNNER="$(bin_dir)/runTests.sh"
 
-success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
-}
-
-warning() {
-    echo -e "${YELLOW}[WARNING]${NC} $1"
-}
-
-error() {
-    echo -e "${RED}[ERROR]${NC} $1"
-}
-
-#
-# Check if composer dependencies are installed
-#
-check_dependencies() {
-    if [[ ! -d "${ROOT_DIR}/.Build/vendor" ]]; then
-        error "Dependencies not installed. Run 'composer install' first."
+if [[ ! -x "${RUNNER}" ]]; then
+    echo "runTests.sh: ${RUNNER} not found — installing dependencies first." >&2
+    if ! type composer >/dev/null 2>&1; then
+        echo "runTests.sh: composer is not on PATH, cannot bootstrap ${RUNNER}." >&2
         exit 1
     fi
-}
+    composer install --no-interaction --no-progress
+fi
 
-#
-# Run unit tests
-#
-run_unit_tests() {
-    info "Running unit tests..."
-    check_dependencies
-
-    local coverage_opts=""
-    if [[ -n "${COVERAGE}" ]]; then
-        coverage_opts="--coverage-html ${ROOT_DIR}/.Build/coverage/html --coverage-clover ${ROOT_DIR}/.Build/coverage/clover.xml"
-        mkdir -p "${ROOT_DIR}/.Build/coverage"
-    fi
-
-    "${VENDOR_BIN}/phpunit" -c "${ROOT_DIR}/Build/phpunit/UnitTests.xml" ${coverage_opts} ${EXTRA_TEST_OPTIONS}
-    success "Unit tests completed"
-
-    if [[ -n "${COVERAGE}" ]]; then
-        info "Coverage report: ${ROOT_DIR}/.Build/coverage/html/index.html"
-    fi
-}
-
-#
-# Run functional tests
-#
-run_functional_tests() {
-    info "Running functional tests with DBMS=${DBMS}..."
-    check_dependencies
-
-    export typo3DatabaseDriver="pdo_sqlite"
-
-    if [[ -f "${ROOT_DIR}/Build/phpunit/FunctionalTests.xml" ]]; then
-        "${VENDOR_BIN}/phpunit" -c "${ROOT_DIR}/Build/phpunit/FunctionalTests.xml" ${EXTRA_TEST_OPTIONS}
-    else
-        warning "FunctionalTests.xml not found, skipping..."
-    fi
-    success "Functional tests completed"
-}
-
-#
-# Run integration tests
-#
-run_integration_tests() {
-    info "Running integration tests..."
-    check_dependencies
-
-    if [[ -f "${ROOT_DIR}/Build/phpunit/IntegrationTests.xml" ]]; then
-        "${VENDOR_BIN}/phpunit" -c "${ROOT_DIR}/Build/phpunit/IntegrationTests.xml" ${EXTRA_TEST_OPTIONS}
-    else
-        warning "IntegrationTests.xml not found, skipping..."
-    fi
-    success "Integration tests completed"
-}
-
-#
-# Run end-to-end tests
-#
-run_e2e_tests() {
-    info "Running end-to-end tests..."
-    check_dependencies
-
-    if [[ -f "${ROOT_DIR}/Build/phpunit/E2ETests.xml" ]]; then
-        "${VENDOR_BIN}/phpunit" -c "${ROOT_DIR}/Build/phpunit/E2ETests.xml" ${EXTRA_TEST_OPTIONS}
-    else
-        warning "E2ETests.xml not found, skipping..."
-    fi
-    success "E2E tests completed"
-}
-
-#
-# Run mutation tests
-#
-run_mutation_tests() {
-    info "Running mutation tests with Infection..."
-    check_dependencies
-
-    if [[ -f "${ROOT_DIR}/Build/infection.json" ]]; then
-        "${VENDOR_BIN}/infection" --configuration="${ROOT_DIR}/Build/infection.json" --threads=4 -s --no-progress
-    else
-        warning "infection.json not found in Build/, skipping..."
-    fi
-    success "Mutation tests completed"
-}
-
-#
-# Run PHPStan
-#
-run_phpstan() {
-    info "Running PHPStan static analysis..."
-    check_dependencies
-    "${VENDOR_BIN}/phpstan" analyse -c "${ROOT_DIR}/Build/phpstan.neon"
-    success "PHPStan analysis completed"
-}
-
-#
-# Run PHP-CS-Fixer (dry-run)
-#
-run_cgl() {
-    info "Running PHP-CS-Fixer (dry-run)..."
-    check_dependencies
-    "${VENDOR_BIN}/php-cs-fixer" fix --dry-run --diff --config="${ROOT_DIR}/Build/.php-cs-fixer.dist.php"
-    success "CGL check completed"
-}
-
-#
-# Run PHP-CS-Fixer (fix)
-#
-run_cgl_fix() {
-    info "Running PHP-CS-Fixer (applying fixes)..."
-    check_dependencies
-    "${VENDOR_BIN}/php-cs-fixer" fix --config="${ROOT_DIR}/Build/.php-cs-fixer.dist.php"
-    success "CGL fixes applied"
-}
-
-#
-# Run Rector (dry-run)
-#
-run_rector() {
-    info "Running Rector (dry-run)..."
-    check_dependencies
-    "${VENDOR_BIN}/rector" process --config "${ROOT_DIR}/Build/rector.php" --dry-run
-    success "Rector analysis completed"
-}
-
-#
-# Run Rector (fix)
-#
-run_rector_fix() {
-    info "Running Rector (applying changes)..."
-    check_dependencies
-    "${VENDOR_BIN}/rector" process --config "${ROOT_DIR}/Build/rector.php"
-    success "Rector changes applied"
-}
-
-#
-# Run CI suite
-#
-run_ci() {
-    info "Running CI suite..."
-    run_cgl
-    run_phpstan
-    run_rector
-    run_unit_tests
-    success "CI suite completed"
-}
-
-#
-# Run all tests and checks
-#
-run_all() {
-    info "Running all tests and quality checks..."
-    run_cgl
-    run_phpstan
-    run_rector
-    run_unit_tests
-    run_functional_tests
-    run_integration_tests
-    run_e2e_tests
-    success "All tests and checks completed"
-}
-
-#
-# Parse command line arguments
-#
-parse_args() {
-    while [[ $# -gt 0 ]]; do
-        case $1 in
-            -h|--help)
-                usage
-                exit 0
-                ;;
-            -v|--verbose)
-                set -x
-                shift
-                ;;
-            -c|--coverage)
-                COVERAGE="1"
-                shift
-                ;;
-            -p|--php)
-                PHP_VERSION="$2"
-                shift 2
-                ;;
-            -d|--dbms)
-                DBMS="$2"
-                shift 2
-                ;;
-            -x)
-                EXTRA_TEST_OPTIONS="$2"
-                shift 2
-                ;;
-            unit)
-                run_unit_tests
-                exit 0
-                ;;
-            functional)
-                run_functional_tests
-                exit 0
-                ;;
-            integration)
-                run_integration_tests
-                exit 0
-                ;;
-            e2e)
-                run_e2e_tests
-                exit 0
-                ;;
-            mutation)
-                run_mutation_tests
-                exit 0
-                ;;
-            phpstan)
-                run_phpstan
-                exit 0
-                ;;
-            cgl)
-                run_cgl
-                exit 0
-                ;;
-            cgl:fix)
-                run_cgl_fix
-                exit 0
-                ;;
-            rector)
-                run_rector
-                exit 0
-                ;;
-            rector:fix)
-                run_rector_fix
-                exit 0
-                ;;
-            ci)
-                run_ci
-                exit 0
-                ;;
-            all)
-                run_all
-                exit 0
-                ;;
-            *)
-                error "Unknown option or command: $1"
-                usage
-                exit 1
-                ;;
-        esac
-    done
-
-    # No command provided
-    usage
+if [[ ! -x "${RUNNER}" ]]; then
+    echo "runTests.sh: ${RUNNER} is still missing after composer install." >&2
+    echo "             Is netresearch/typo3-ci-workflows in require-dev?" >&2
     exit 1
-}
+fi
 
-#
-# Main entry point
-#
-main() {
-    cd "${ROOT_DIR}"
-
-    if [[ $# -eq 0 ]]; then
-        usage
-        exit 1
-    fi
-
-    parse_args "$@"
-}
-
-main "$@"
+exec "${RUNNER}" "$@"

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "netresearch/nr-llm": "^0.33"
     },
     "require-dev": {
-        "netresearch/typo3-ci-workflows": "^1.3"
+        "netresearch/typo3-ci-workflows": "^1.8.1"
     },
     "autoload": {
         "psr-4": {
@@ -102,28 +102,28 @@
         }
     },
     "scripts": {
-        "ci:cgl": "Build/Scripts/runTests.sh cgl:fix",
-        "ci:rector": "Build/Scripts/runTests.sh rector:fix",
+        "ci:cgl": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then php-cs-fixer fix --config Build/.php-cs-fixer.dist.php \"$@\"; else ./Build/Scripts/runTests.sh -s cgl \"$@\"; fi' --",
+        "ci:rector": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then rector process --config Build/rector.php \"$@\"; else ./Build/Scripts/runTests.sh -s rector \"$@\"; fi' --",
         "ci:security": "composer audit",
-        "ci:test:php:cgl": "Build/Scripts/runTests.sh cgl",
+        "ci:test:php:cgl": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then php-cs-fixer fix --config Build/.php-cs-fixer.dist.php --dry-run --diff \"$@\"; else ./Build/Scripts/runTests.sh -s cgl -n \"$@\"; fi' --",
         "ci:test:php:lint": [
             "phplint --configuration Build/.phplint.yml"
         ],
-        "ci:test:php:phpstan": "Build/Scripts/runTests.sh phpstan",
+        "ci:test:php:phpstan": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then phpstan analyse -c Build/phpstan.neon \"$@\"; else ./Build/Scripts/runTests.sh -s phpstan \"$@\"; fi' --",
         "ci:test:php:phpstan:baseline": [
             "phpstan analyze --configuration Build/phpstan.neon --memory-limit=-1 --generate-baseline Build/phpstan-baseline.neon --allow-empty-baseline"
         ],
-        "ci:test:php:rector": "Build/Scripts/runTests.sh rector",
+        "ci:test:php:rector": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then rector process --config Build/rector.php --dry-run \"$@\"; else ./Build/Scripts/runTests.sh -s rector -n \"$@\"; fi' --",
         "ci:test": [
             "@ci:test:php:lint",
             "@ci:test:php:phpstan",
             "@ci:test:php:rector",
             "@ci:test:php:cgl"
         ],
-        "ci:test:php:unit": "Build/Scripts/runTests.sh unit",
-        "ci:test:php:integration": "Build/Scripts/runTests.sh integration",
-        "ci:test:php:e2e": "Build/Scripts/runTests.sh e2e",
-        "ci:test:php:functional": "Build/Scripts/runTests.sh functional",
+        "ci:test:php:unit": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then phpunit -c Build/phpunit/UnitTests.xml \"$@\"; else ./Build/Scripts/runTests.sh -s unit \"$@\"; fi' --",
+        "ci:test:php:integration": "phpunit -c Build/phpunit/IntegrationTests.xml",
+        "ci:test:php:e2e": "phpunit -c Build/phpunit/E2ETests.xml",
+        "ci:test:php:functional": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then phpunit -c Build/phpunit/FunctionalTests.xml \"$@\"; else ./Build/Scripts/runTests.sh -s functional \"$@\"; fi' --",
         "ci:test:all": [
             "@ci:test:php:unit",
             "@ci:test:php:functional",


### PR DESCRIPTION
Seventeenth extension on the shared runner, 370 lines to 47.

| Suite | Wrapper | Shared runner |
| --- | --- | --- |
| `unit` | 614 tests, 1653 assertions, exit 0 | identical |

## The composer scripts

They called the runner with a positional suite name (`runTests.sh unit`), which the shared runner reads as a test file. They now branch the way `t3x-nr-llm`'s do — inside a container or with `CI` set, call the tool directly; otherwise the runner. That is needed because the shared workflow appends arguments after a separator (`composer ci:test:php:unit -- --coverage-clover=…`) and the runner rejects them: `illegal option -- -`. The wrapper being replaced passed them through, so this is a capability the shared runner is missing, filed as netresearch/typo3-ci-workflows#211.

## Two suites deliberately bypass the runner

**`integration`** — `-s integration` ran `Build/phpunit/UnitTests.xml`: 614 tests, the unit suite under another name, **exit 0**. The runner has no candidate list for a separate integration config; it only picks a testsuite *name* inside an already-detected one. The five integration test classes were never opened, and nothing in the output said so. netresearch/typo3-ci-workflows#212.

**`e2e`** — `-s e2e` means Playwright against a running TYPO3 and asks for a URL. This extension's e2e is a PHPUnit config.

Both now call phpunit against their own config, and I checked the `Configuration:` line each run prints rather than trusting the exit code — that is the only place the first problem was visible.

## Noted, not changed

`Tests/Functional` holds only a `.gitkeep`, so the functional suite runs no tests and both runners report success. That is PHPUnit's default for an empty-but-present suite, not something either runner adds. CI passes `run-functional-tests: true`, so it has been running an empty suite green for as long as the directory has been empty.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_
